### PR TITLE
release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sandbox shell_command tool execution (currently no isolation)
 - Array index support in state paths (e.g., `state.items[0]`)
 
+## [0.1.1] - 2026-03-22
+
+### Fixed
+
+- Rate limiter now accounts for response tokens, not just prompt tokens (#11)
+- README header image uses absolute URLs for PyPI compatibility (#2)
+
 ## [0.1.0] - 2026-03-19
 
 First public release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentloom"
-version = "0.1.0"
+version = "0.1.1"
 description = "Production-ready agentic workflow orchestrator with native observability, resilience, and cost control."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.1
- Update CHANGELOG with fixes included in this release

### Changes in v0.1.1
- **Fixed:** Rate limiter now accounts for response tokens, not just prompt tokens (#11)
- **Fixed:** README header image uses absolute URLs for PyPI compatibility (#2)

## Test plan
- [x] Version bump only + CHANGELOG update
- [x] No code changes in this PR