### PR TITLE
bump version to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Sandbox enforcement for built-in tools — command allowlist, path restrictions, network control (#4)
-- `SandboxConfig` model in workflow YAML (`config.sandbox.*`)
-- `SandboxViolationError` exception
-
-### Fixed
-
-- Step executors (`llm_call`, `router`, `tool_step`) now use `await get_state_snapshot()` instead of sync `.state` access (#8)
-
 ### Planned
 
 - Streaming responses from providers (currently falls back to full completion)
 - YAML-based provider config (replace env var discovery)
 - Load pricing table from YAML instead of hardcoded Python dict
-- ~~Sandbox shell_command tool execution (currently no isolation)~~
 - Array index support in state paths (e.g., `state.items[0]`)
+
+## [0.1.2] - 2026-03-26
+
+### Added
+
+- Sandbox enforcement for built-in tools — command allowlist, path restrictions (read/write separation), network domain filtering, shell operator injection prevention, write size limits (#4)
+- `SandboxConfig` model in workflow YAML (`config.sandbox.*`)
+- `SandboxViolationError` exception
+- Sandbox workflow examples (`17_sandbox_allowed`, `18_sandbox_blocked`)
+
+### Fixed
+
+- Step executors (`llm_call`, `router`, `tool_step`) now use `await get_state_snapshot()` instead of sync `.state` access (#8)
+- Removed deprecated `gemini-2.0-flash` model
 
 ## [0.1.1] - 2026-03-22
 
@@ -53,14 +56,14 @@ First public release.
 
 - No streaming support (falls back to full completion)
 - Router expressions use first-match-wins, no priority ordering
-- Rate limiter doesn't account for response tokens (only prompt tokens)
+- ~~Rate limiter doesn't account for response tokens (only prompt tokens)~~ (fixed in 0.1.1)
 - Provider discovery from env vars only, should be a config file
-- Shell command tool has no sandboxing (FIXME in code)
-- File tools accept arbitrary paths (no path sanitization)
+- ~~Shell command tool has no sandboxing (FIXME in code)~~ (fixed in 0.1.2)
+- ~~File tools accept arbitrary paths (no path sanitization)~~ (fixed in 0.1.2)
 - Router expressions use `eval()` — must be trusted input (not user-facing)
 - Pricing table hardcoded in Python, should be YAML config
 - No array index support in state paths (e.g., `state.items[0]`)
-- ~~Sync state access in step executors bypasses async lock~~ (fixed)
+- ~~Sync state access in step executors bypasses async lock~~ (fixed in 0.1.2)
 - Budget enforcement is post-hoc — a single expensive step can overshoot before being stopped
 - `budget_remaining` metric only emitted to Prometheus, not OTel
 - Checkpoint `save_checkpoint` uses blocking I/O inside async method
@@ -78,5 +81,7 @@ First public release.
 - **Pydantic v2** — validation and serialization worth the Rust compilation
   trade-off. Could revisit for truly minimal environments.
 
-[Unreleased]: https://github.com/cchinchilla-dev/agentloom/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/cchinchilla-dev/agentloom/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/cchinchilla-dev/agentloom/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/cchinchilla-dev/agentloom/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/cchinchilla-dev/agentloom/releases/tag/v0.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agentloom"
-version = "0.1.1"
+version = "0.1.2"
 description = "Production-ready agentic workflow orchestrator with native observability, resilience, and cost control."
 readme = "README.md"
 license = "MIT"

--- a/src/agentloom/__init__.py
+++ b/src/agentloom/__init__.py
@@ -1,3 +1,3 @@
 """AgentLoom: Production-ready agentic workflow orchestrator."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.2"


### PR DESCRIPTION
## Summary
- Bump version from 0.1.1 to 0.1.2
- Update changelog with 0.1.2 release notes (sandbox #4, state fix #8, gemini cleanup)
- Update Known Limitations strikethroughs with version references

**Changelog**: https://github.com/cchinchilla-dev/agentloom/blob/release/v0.1.2/CHANGELOG.md