### PR TITLE
upgrade actions to node 24 and improve pr labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,7 +31,13 @@ tests:
 documentation:
   - changed-files:
       - any-glob-to-any-file:
-          - "**/*.md"
+          - docs/**
+          - README.md
+          - CONTRIBUTING.md
+          - CODE_OF_CONDUCT.md
+          - deploy/INFRASTRUCTURE.md
+          - deploy/DASHBOARD.md
+          - examples/README.md
 
 infrastructure:
   - changed-files:
@@ -39,8 +45,21 @@ infrastructure:
           - deploy/**
           - Dockerfile
           - .dockerignore
+          - scripts/audit_infra.py
+          - scripts/audit_integration.py
 
 ci:
   - changed-files:
       - any-glob-to-any-file:
-          - .github/**
+          - .github/workflows/**
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - pyproject.toml
+          - uv.lock
+
+release:
+  - changed-files:
+      - any-glob-to-any-file:
+          - CHANGELOG.md

--- a/.github/labels.json
+++ b/.github/labels.json
@@ -16,5 +16,7 @@
   {"name": "ci", "color": "bfd4f2", "description": "CI/CD changes"},
   {"name": "dependencies", "color": "0366d6", "description": "Dependency updates"},
   {"name": "internal", "color": "ededed", "description": "Internal refactoring"},
-  {"name": "skip-changelog", "color": "ededed", "description": "Exclude from release notes"}
+  {"name": "skip-changelog", "color": "ededed", "description": "Exclude from release notes"},
+  {"name": "release", "color": "6f42c1", "description": "Version bump and release prep"},
+  {"name": "infrastructure", "color": "0E8A16", "description": "Deployment, Docker, K8s, Helm, Terraform"}
 ]

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,24 @@
+name: Auto Tag
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create version tag
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.head_commit.message, 'bump version to')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+
+      - name: Extract version and create tag
+        run: |
+          VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          TAG="v${VERSION}"
+          echo "Tagging ${TAG}"
+          git tag "${TAG}"
+          git push origin "${TAG}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     name: Lint & type check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8
         with:
           enable-cache: true
       - run: uv sync --group dev
@@ -34,14 +34,14 @@ jobs:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
-      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
       - run: uv sync --group dev --all-extras
       - run: uv run pytest --cov=agentloom --cov-report=xml --cov-report=term-missing
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
         if: matrix.python-version == '3.12'
         with:
           name: coverage
@@ -51,7 +51,7 @@ jobs:
     name: Validate K8s manifests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - name: Install tools
         run: |
           curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.6.0/kustomize_v5.6.0_linux_amd64.tar.gz" | tar xz -C /usr/local/bin

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build & Push
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
 
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
       - uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a  # v2
         with:
           config-file: .github/labels.json

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -13,6 +13,6 @@ jobs:
     name: Auto-label PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9  # v5
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b  # v6
         with:
           configuration-path: .github/labeler.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,14 +13,14 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8
         with:
           enable-cache: true
       - run: uv build --wheel
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
         with:
           name: dist
           path: dist/
@@ -30,12 +30,12 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: dist
           path: dist/
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
@@ -52,7 +52,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,7 +13,7 @@ jobs:
     name: Close stale issues
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f  # v10
         with:
           days-before-issue-stale: 60
           days-before-issue-close: 14


### PR DESCRIPTION
## Summary

- Bump 6 GitHub Actions to Node 24-compatible major versions (checkout v6, setup-uv v8, upload-artifact v7, download-artifact v8, stale v10, labeler v6)
- Fix `documentation` label triggering on almost every PR by replacing `**/*.md` with explicit doc file paths
- Narrow `ci` label from `.github/**` to `.github/workflows/**`
- Add `dependencies` label rule for `pyproject.toml` and `uv.lock`
- Add `release` label rule for `CHANGELOG.md` and version bump PRs
- Add auto-tag workflow that creates `vX.Y.Z` tag when a version bump merges to main

## Test plan

- [x] CI passes with new action versions
- [x] Labeler config is valid YAML
- [x] Auto-tag workflow syntax is valid (validated by CI)