### PR TITLE
add mkdocs-material documentation site (#72)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,27 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Deploy documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57  # v8
+        with:
+          enable-cache: true
+      - run: uv sync --group docs
+      - run: uv run mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ node_modules/
 .claude/worktrees/
 .claude/CLAUDE.md
 deploy/terraform/agentloom-dev-config
+site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Documentation site with mkdocs-material — getting started, architecture, providers, workflow YAML reference, Python DSL, graph API, examples, observability, deployment, contributing, and changelog pages. Auto-deployed to GitHub Pages on push to main (#72)
 - Multi-modal input support for `llm_call` steps — images, PDFs, and audio via `attachments` field (#68)
   - Provider-native formatting: OpenAI (images, audio), Anthropic (images, PDFs), Google (images, PDFs, audio), Ollama (images)
   - URL fetching with `fetch: local` (default) or `fetch: provider` passthrough

--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@
   <a href="https://codecov.io/github/cchinchilla-dev/agentloom"><img src="https://codecov.io/github/cchinchilla-dev/agentloom/graph/badge.svg" alt="Coverage"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python 3.11+"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-green.svg" alt="License: MIT"></a>
+  <a href="https://cchinchilla-dev.github.io/agentloom/"><img src="https://img.shields.io/badge/docs-mkdocs-blue.svg" alt="Docs"></a>
 </p>
 
 ---
 
 ## Table of Contents
 
+- [Documentation](https://cchinchilla-dev.github.io/agentloom/)
 - [Why AgentLoom?](#why-agentloom)
 - [Quick Start](#quick-start)
 - [Architecture](#architecture)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,142 @@
+# Architecture
+
+AgentLoom is a **deterministic workflow orchestrator** — not an autonomous agent framework. You define the DAG, the engine executes it.
+
+## Overview
+
+```
++-----------------------------------------------------+
+|                   CLI / Python API                  |
++-----------------------------------------------------+
+|                   Workflow Engine                   |
+|  +-----------+  +-----------+  +---------------+    |
+|  |DAG Parser |  | Scheduler |  | State Manager |    |
+|  |& Validator|  |  (anyio)  |  |  (Pydantic)   |    |
+|  +-----------+  +-----------+  +---------------+    |
++-----------------------------------------------------+
+|                   Step Executors                    |
+|  +--------+ +---------+ +------+ +------------+     |
+|  |LLM Call| |Tool Exec| |Router| | Subworkflow|     |
+|  +--------+ +---------+ +------+ +------------+     |
++-----------------------------------------------------+
+|                  Provider Gateway                   |
+|  +-----------------------------------------------+  |
+|  | OpenAI | Anthropic | Google | Ollama          |  |
+|  | + Fallback | Circuit Breaker | Rate Limiter   |  |
+|  +-----------------------------------------------+  |
++-----------------------------------------------------+
+|              Observability (optional)               |
+|  +------------+  +----------+  +----------+         |
+|  | OTel Traces|  |Prometheus|  | JSON Logs|         |
+|  +------------+  +----------+  +----------+         |
++-----------------------------------------------------+
+```
+
+## Execution flow
+
+The engine processes a workflow in five phases:
+
+### 1. DAG construction
+
+The parser reads the YAML (or Python DSL output) and builds a directed acyclic graph from step definitions and their `depends_on` fields. Cycle detection runs at parse time — circular dependencies are rejected before execution starts.
+
+### 2. Layer extraction
+
+Topological sort groups steps into **execution layers**. Each layer contains steps with no inter-dependencies, meaning they can run in parallel.
+
+```mermaid
+graph LR
+    A[Layer 0: fetch, validate] --> B[Layer 1: classify]
+    B --> C[Layer 2: route]
+    C --> D[Layer 3: handle_billing, handle_technical, handle_general]
+```
+
+### 3. Parallel execution
+
+For each layer, the engine:
+
+1. Filters active steps (skips those blocked by router decisions)
+2. Launches concurrent tasks via `anyio` task groups (up to `max_concurrent_steps`)
+3. Waits for the layer to complete before advancing
+
+### 4. Router handling
+
+Router steps evaluate conditions against the current state and output a target step ID. Downstream steps not activated by the router are marked as **skipped** — they never execute.
+
+### 5. Result aggregation
+
+After all layers complete, the engine collects step results and computes totals (tokens, cost, duration). The final workflow status is `SUCCESS` if all steps passed, `FAILED` if any step failed, `TIMEOUT` if the deadline was exceeded, or `BUDGET_EXCEEDED` if the cost limit was hit.
+
+## Result models
+
+### WorkflowResult
+
+Returned by `engine.run()` after workflow execution completes:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workflow_name` | `str` | Workflow identifier |
+| `status` | `WorkflowStatus` | `success`, `failed`, `timeout`, or `budget_exceeded` |
+| `step_results` | `dict[str, StepResult]` | All step outputs and metadata |
+| `final_state` | `dict[str, Any]` | State snapshot after completion |
+| `total_duration_ms` | `float` | Total wall-clock time |
+| `total_tokens` | `int` | Sum of all tokens consumed |
+| `total_cost_usd` | `float` | Estimated total cost |
+| `error` | `str | None` | First failure message, if any |
+
+### StepResult
+
+Metadata and output for each individual step:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `step_id` | `str` | Step identifier |
+| `status` | `StepStatus` | `pending`, `running`, `success`, `failed`, `skipped`, or `timeout` |
+| `output` | `Any` | Step output value |
+| `error` | `str | None` | Failure reason |
+| `duration_ms` | `float` | Step execution time |
+| `token_usage` | `TokenUsage` | Prompt, completion, and total tokens |
+| `cost_usd` | `float` | Estimated step cost |
+| `model` | `str | None` | Model used (LLM steps) |
+| `provider` | `str | None` | Provider name |
+| `attachment_count` | `int` | Multi-modal attachment count |
+| `time_to_first_token_ms` | `float | None` | TTFT for streaming steps |
+
+## State management
+
+The `StateManager` provides async-safe shared state with dotted-key access:
+
+```python
+state["user.profile.email"]    # nested access
+state["items[0].name"]         # array indexing
+```
+
+- All steps in a workflow share the same state instance
+- Steps with `output: key` write their result to `state[key]`
+- Templates use `{state.key}` or `{key}` (flat namespace) for interpolation
+- State is implemented with Pydantic models for validation
+
+## Provider gateway
+
+The gateway routes requests based on model name and manages resilience:
+
+| Feature | Description |
+|---------|-------------|
+| **Fallback** | Providers are tried in priority order. If one fails, the next is attempted automatically |
+| **Circuit breaker** | After 5 consecutive failures, a provider is taken offline for 60 seconds |
+| **Rate limiter** | Token-bucket algorithm enforces requests/minute and tokens/minute limits |
+
+See [Providers](providers.md) for provider-specific details.
+
+## Design principles
+
+!!! tip "Why not autonomous agents?"
+
+    Most LLM frameworks focus on autonomous agents with self-directed reasoning and unbounded tool loops. This works for demos but breaks in production where you need predictable costs, debuggable failures, and SLA compliance.
+
+    AgentLoom takes a different approach:
+
+    - **You define the DAG, not the LLM.** The model generates text within a step — it does not decide what runs next.
+    - **Observability is not optional.** Every step emits traces and metrics.
+    - **Cost is bounded.** Budget limits and circuit breakers are first-class.
+    - **Fallback is structural.** Provider routing happens at the infrastructure level, not via agent "choice."

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ AgentLoom is a **deterministic workflow orchestrator** — not an autonomous age
 |                   Workflow Engine                   |
 |  +-----------+  +-----------+  +---------------+    |
 |  |DAG Parser |  | Scheduler |  | State Manager |    |
-|  |& Validator|  |  (anyio)  |  |  (Pydantic)   |    |
+|  |& Validator|  |  (anyio)  |  |  (dict+lock)  |    |
 |  +-----------+  +-----------+  +---------------+    |
 +-----------------------------------------------------+
 |                   Step Executors                    |
@@ -114,7 +114,7 @@ state["items[0].name"]         # array indexing
 - All steps in a workflow share the same state instance
 - Steps with `output: key` write their result to `state[key]`
 - Templates use `{state.key}` or `{key}` (flat namespace) for interpolation
-- State is implemented with Pydantic models for validation
+- Workflow state is stored as a plain dictionary and accessed/updated through `StateManager`
 
 ## Provider gateway
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,95 @@
+# Changelog
+
+All notable changes to this project are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- **Documentation site** with mkdocs-material — full reference docs auto-deployed to GitHub Pages
+- **Multi-modal input** for `llm_call` steps — images, PDFs, and audio via `attachments` field
+    - Provider-native formatting: OpenAI (images, audio), Anthropic (images, PDFs), Google (images, PDFs, audio), Ollama (images)
+    - URL fetching with `fetch: local` (default) or `fetch: provider` passthrough
+    - SSRF protection: blocks private/reserved IP ranges (RFC 1918, loopback, link-local)
+    - Sandbox integration: `allowed_domains`, `allow_network`, and `readable_paths` enforced
+    - Grafana dashboard "Multi-modal" row with attachment panels
+    - Multi-modal workflow examples (19-24)
+- **Streaming** for LLM responses with real-time token output
+    - `StreamResponse` accumulator with per-provider SSE/NDJSON parsing
+    - All 4 providers: OpenAI (SSE), Anthropic (SSE), Google (SSE), Ollama (NDJSON)
+    - Gateway `stream()` with circuit breaker + rate limiter integration
+    - `config.stream: true` (workflow-level) and per-step `stream:` override
+    - CLI `--stream` flag, `time_to_first_token_ms` in `StepResult`
+    - Grafana "Streaming" dashboard row with TTFT quantiles
+    - Streaming examples (25-26)
+- **`AGENTLOOM_*` env var prefix** for all configuration overrides
+- **YAML-based pricing table** replacing hardcoded Python dict
+- **Provider auto-discovery** moved from CLI hack to `config.discover_providers()`
+- **Ollama e2e integration tests** against a live Docker instance
+- **Array index support** in state paths (`state.items[0]`, `results[-1]`)
+- **First-class graph API** for workflow DAG analysis and export
+    - `WorkflowGraph` class with path algorithms and export formats
+    - Graphviz DOT, Mermaid, PNML, NetworkX, JSON
+- **Test coverage reporting** via Codecov with 85% minimum threshold
+
+## [0.2.0] — 2026-03-30
+
+### Added
+
+- Kubernetes manifests with Kustomize overlays for dev, staging, and production
+- Helm chart with Job/CronJob modes and render-time input validation
+- Terraform configuration for local kind cluster with full observability stack
+- ArgoCD Application CRD with automated sync and Job immutability handling
+- Docker CI/CD workflow for multi-arch GHCR publishing
+- Infrastructure documentation
+
+### Fixed
+
+- Production NetworkPolicy OTel egress restricted to observability namespace
+- Read-only filesystem audit check no longer false-passes
+- Terraform audit phase passes KUBECONFIG to all kubectl poll commands
+- GitHub Actions and image versions pinned to commit SHAs
+
+## [0.1.2] — 2026-03-26
+
+### Added
+
+- **Sandbox enforcement** for built-in tools — command allowlist, path restrictions, network domain filtering, shell operator injection prevention, write size limits
+- `SandboxConfig` model in workflow YAML (`config.sandbox.*`)
+- Sandbox workflow examples (17, 18)
+
+### Fixed
+
+- Step executors now use `await get_state_snapshot()` instead of sync `.state` access
+- Removed deprecated `gemini-2.0-flash` model
+
+## [0.1.1] — 2026-03-22
+
+### Fixed
+
+- Rate limiter now accounts for response tokens, not just prompt tokens
+- README header image uses absolute URLs for PyPI compatibility
+
+## [0.1.0] — 2026-03-19
+
+First public release.
+
+### Added
+
+- YAML and Python DSL workflow definitions (DAGs with sequential + parallel steps)
+- Step types: `llm_call`, `tool`, `router` (conditional), `subworkflow`
+- Provider gateway with automatic fallback (OpenAI, Anthropic, Google, Ollama)
+- Circuit breaker, rate limiter, and retry with exponential backoff per provider
+- Budget enforcement (hard stop when USD limit exceeded)
+- Cost tracking per step, model, and provider
+- OpenTelemetry traces + Prometheus metrics (optional)
+- CLI commands: `run`, `validate`, `visualize` (ASCII + Mermaid), `info`
+- Checkpointing: save and resume workflow state to disk
+
+### Design Decisions
+
+- **httpx over provider SDKs** — keeps dependencies minimal (~5 core)
+- **anyio over raw asyncio** — structured concurrency via task groups
+- **str.format_map over Jinja2** — one fewer dependency; prompt templates don't need loops
+- **Observability optional** — core runs without opentelemetry or prometheus
+- **Pydantic v2** — validation and serialization worth the compilation trade-off

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,87 @@
+# Contributing
+
+Thanks for considering a contribution. Here's how to get started.
+
+## Setup
+
+```bash
+# Fork the repo on GitHub, then:
+git clone https://github.com/<your-user>/agentloom.git
+cd agentloom
+git remote add upstream https://github.com/cchinchilla-dev/agentloom.git
+
+# Install dev dependencies (requires uv)
+uv sync --group dev --all-extras
+
+# Verify
+uv run pytest
+```
+
+## Development workflow
+
+1. Sync your fork: `git fetch upstream && git rebase upstream/main`
+2. Create a branch: `git checkout -b my-feature`
+3. Make your changes
+4. Run the quality gate:
+
+```bash
+uv run pytest                    # tests
+uv run ruff check src/ tests/    # lint
+uv run ruff format src/ tests/   # format
+uv run mypy src/                 # type check
+```
+
+5. Push to your fork and open a pull request against `upstream/main`
+
+## Code style
+
+| Rule | Details |
+|------|---------|
+| Python | 3.11+ with type hints on all public APIs |
+| Models | Pydantic v2 for validation |
+| Async | `anyio` — never raw `asyncio` |
+| HTTP | `httpx` direct — no provider SDKs |
+| Formatting | `ruff` handles formatting and linting |
+| Type checking | `mypy --strict` must pass |
+
+## Tests
+
+- Use `pytest` with `pytest-asyncio` (auto mode)
+- Mock HTTP calls with `respx` — no real API keys in tests
+- Focus on behavior, not implementation details
+- Mirror the source tree: `tests/core/`, `tests/providers/`, etc.
+
+## Commit messages
+
+Short, lowercase, imperative mood:
+
+```
+add retry jitter configuration
+fix router expression parsing for nested attributes
+refactor gateway fallback logic
+```
+
+## Pull requests
+
+- Keep PRs focused — one feature or fix per PR
+- Link issues: `Closes #123` in the PR description
+- All CI checks must pass before merge
+- PRs are squash-merged to keep history clean
+
+## Adding a provider
+
+1. Create `src/agentloom/providers/<name>.py` extending `BaseProvider`
+2. Register it in `providers/gateway.py`
+3. Add pricing data to `providers/pricing.py`
+4. Add tests in `tests/providers/`
+5. Update the README comparison table
+
+## Adding a step type
+
+1. Create `src/agentloom/steps/<name>.py` extending `BaseStep`
+2. Register it in `steps/registry.py`
+3. Add tests in `tests/steps/`
+
+## Reporting bugs
+
+Use the [bug report template](https://github.com/cchinchilla-dev/agentloom/issues/new?template=bug_report.yml) and include your workflow YAML if applicable.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,228 @@
+# Deployment
+
+AgentLoom runs anywhere — from a single Docker container to a fully orchestrated Kubernetes cluster with GitOps and observability. The CLI processes a workflow and exits; there is no long-running server.
+
+!!! tip "Why Jobs, not Deployments?"
+    AgentLoom is a CLI that exits after processing. Kubernetes **Jobs** provide finite execution, automatic retries via `backoffLimit`, scheduled runs via CronJobs, and clean resource isolation per workflow.
+
+## Docker
+
+The multi-stage Dockerfile produces a minimal image (~120MB) with a non-root user and read-only filesystem.
+
+```bash
+# Build
+docker build -t agentloom .
+
+# Run a workflow
+docker run --rm \
+  -e OPENAI_API_KEY=sk-... \
+  -v ./examples:/workflows:ro \
+  agentloom run /workflows/01_simple_qa.yaml
+
+# Override provider and model
+docker run --rm \
+  -e OPENAI_API_KEY=sk-... \
+  -v ./examples:/workflows:ro \
+  agentloom run /workflows/01_simple_qa.yaml --provider openai --model gpt-4o-mini
+
+# Build with observability extras
+docker build --build-arg BUILD_OBSERVABILITY=true -t agentloom:obs .
+```
+
+## Docker Compose
+
+Runs AgentLoom alongside the full observability stack:
+
+```bash
+cd deploy
+
+# Start observability stack
+docker compose up -d
+
+# Run a workflow (on-demand, not part of `up`)
+docker compose run --rm agentloom run /workflows/01_simple_qa.yaml
+
+# Stop everything
+docker compose down
+```
+
+| Service | Port | Purpose |
+|---------|------|---------|
+| Grafana | 3000 | Dashboard visualization (admin/admin) |
+| Prometheus | 9090 | Metrics storage and PromQL queries |
+| Jaeger | 16686 | Distributed tracing UI |
+| OTel Collector | 4317 | Receives traces and metrics via gRPC |
+
+## Kubernetes (Kustomize)
+
+Plain YAML manifests organized with Kustomize overlays. Three environments provided:
+
+| Overlay | Image Tag | Memory (req/limit) | CPU Request | NetworkPolicy | Deadline |
+|---------|-----------|---------------------|-------------|---------------|----------|
+| **dev** | `latest` | 64Mi / 128Mi | 50m | Disabled | — |
+| **staging** | CI SHA | 128Mi / 256Mi | 100m | Enabled | — |
+| **production** | Pinned | 256Mi / 512Mi | 200m | Strict (no Ollama) | 600s |
+
+```bash
+# Deploy dev overlay
+kubectl apply -k deploy/k8s/overlays/dev
+kubectl logs job/agentloom-workflow -n agentloom
+
+# Clean up
+kubectl delete -k deploy/k8s/overlays/dev
+```
+
+!!! warning "Secrets"
+    The base secret ships with `data: {}` by design. Populate it before deploying:
+    ```bash
+    kubectl create secret generic agentloom-provider-keys \
+      --from-literal=OPENAI_API_KEY=sk-... \
+      --from-literal=ANTHROPIC_API_KEY=sk-ant-... \
+      -n agentloom --dry-run=client -o yaml | kubectl apply -f -
+    ```
+
+!!! info "No CPU limits"
+    No overlay sets CPU limits — this is intentional. CPU limits cause CFS throttling during LLM API calls (which are I/O-bound, not CPU-bound). CPU requests are set for scheduling guarantees.
+
+## Helm
+
+Recommended for parameterized deployments. The chart validates inputs at render time — deploying without a workflow definition fails at render time, not at runtime.
+
+=== "One-shot Job"
+
+    ```bash
+    helm install agentloom deploy/helm/agentloom \
+      -n agentloom --create-namespace \
+      --set workflow.definition="$(cat examples/01_simple_qa.yaml)" \
+      --set provider.existingSecret=my-secret
+    ```
+
+=== "CronJob (scheduled)"
+
+    ```bash
+    helm install agentloom deploy/helm/agentloom \
+      -n agentloom --create-namespace \
+      --set schedule.enabled=true \
+      --set schedule.cron="0 */6 * * *" \
+      --set workflow.definition="$(cat examples/01_simple_qa.yaml)"
+    ```
+
+??? abstract "Helm chart reference"
+
+    | Parameter | Default | Description |
+    |-----------|---------|-------------|
+    | `image.repository` | `ghcr.io/cchinchilla-dev/agentloom` | Container image repository |
+    | `image.tag` | `""` | Image tag (defaults to `appVersion`) |
+    | `workflow.definition` | `""` | Inline workflow YAML |
+    | `workflow.existingConfigMap` | `""` | Reference to existing ConfigMap |
+    | `workflow.args` | `[]` | Extra CLI arguments |
+    | `schedule.enabled` | `false` | `false` = Job, `true` = CronJob |
+    | `schedule.cron` | `0 */6 * * *` | CronJob schedule |
+    | `schedule.timeZone` | `UTC` | CronJob timezone |
+    | `provider.existingSecret` | `""` | Pre-created Secret with API keys |
+    | `provider.openaiApiKey` | `""` | OpenAI key (not recommended) |
+    | `observability.enabled` | `true` | Enable OTel endpoint env var |
+    | `observability.otelEndpoint` | `http://otel-collector:4317` | OTel Collector endpoint |
+    | `job.backoffLimit` | `2` | Retry attempts on failure |
+    | `job.ttlSecondsAfterFinished` | `3600` | Cleanup delay after completion |
+    | `job.activeDeadlineSeconds` | `null` | Hard timeout |
+    | `serviceAccount.create` | `true` | Create a ServiceAccount |
+    | `serviceAccount.automountServiceAccountToken` | `false` | Mount K8s API token |
+    | `namespace.create` | `false` | Create namespace with PSS labels |
+    | `networkPolicy.enabled` | `true` | Enable NetworkPolicy |
+    | `networkPolicy.allowOllama` | `true` | Allow egress to Ollama (port 11434) |
+    | `resourceQuota.enabled` | `false` | Enable namespace ResourceQuota |
+
+    **Validation:** The chart fails at render time if neither `workflow.definition` nor `workflow.existingConfigMap` is set, or if both are set simultaneously.
+
+    **Jobs and immutability:** Kubernetes Jobs are immutable after creation. Use `helm uninstall` + `helm install` for changes, or use ArgoCD with `Replace=true`.
+
+## Terraform
+
+Provisions a complete local development environment in one command: kind cluster + AgentLoom + observability stack.
+
+```bash
+cd deploy/terraform
+cp terraform.tfvars.example terraform.tfvars
+terraform init && terraform apply
+```
+
+When `enable_observability = true` (default), Terraform deploys the full stack:
+
+| Component | URL | Purpose |
+|-----------|-----|---------|
+| OTel Collector | gRPC :4317 | Receives traces and metrics |
+| Jaeger | http://localhost:16686 | Trace storage and UI |
+| Prometheus | http://localhost:9090 | Metrics scraping |
+| Grafana | http://localhost:3000 | Dashboards (admin/admin) |
+
+Set `enable_observability = false` for a lightweight setup without the observability stack.
+
+## ArgoCD
+
+GitOps deployment with automated sync, self-heal, and retry policies. ArgoCD watches the Helm chart in the repository and syncs changes automatically.
+
+```bash
+kubectl apply -f deploy/argocd/application.yaml
+```
+
+The Application CRD configures:
+
+- **Automated sync** with prune and self-heal
+- **Replace=true** for immutable resources (K8s Jobs cannot be patched in-place)
+- **ignoreDifferences** on Job selector/labels to prevent perpetual out-of-sync
+- **Retry policy**: 5 attempts with exponential backoff (5s -> 3m max)
+- **CreateNamespace**: the `agentloom` namespace is created if it does not exist
+
+!!! note "Secrets"
+    Secrets are not managed by ArgoCD. Create them manually or use External Secrets Operator / Sealed Secrets / SOPS.
+
+## Environment variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OPENAI_API_KEY` | OpenAI API key | — |
+| `ANTHROPIC_API_KEY` | Anthropic API key | — |
+| `GOOGLE_API_KEY` | Google AI API key | — |
+| `OLLAMA_BASE_URL` | Ollama server URL | `http://localhost:11434` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTel Collector gRPC endpoint | `http://localhost:4317` |
+
+In Kubernetes, these are injected via `envFrom` referencing a Secret. Never bake API keys into images or commit them to source control.
+
+## CI/CD pipeline
+
+| Workflow | Trigger | What it does |
+|----------|---------|--------------|
+| `ci.yml` | Push / PR to `main` | Lint, type check, test, Docker build, K8s validation, Helm lint |
+| `docker.yml` | Push to `main` / tags `v*` | Build multi-arch image, push to GHCR |
+| `release.yml` | Tags `v*` | Build wheel, GitHub release, publish to PyPI |
+| `docs.yml` | Push to `main` (docs/mkdocs.yml) | Build and deploy documentation to GitHub Pages |
+| `e2e-ollama.yml` | Weekly / `release/**` / `e2e` label | Ollama integration tests against live Docker instance |
+| `pr-labeler.yml` | PR opened/updated | Auto-label PRs based on file paths |
+| `labels.yml` | Push to `main` (labels.json) | Sync GitHub labels from config |
+| `stale.yml` | Weekly (Monday 9am UTC) | Mark/close stale issues |
+
+### Image tags
+
+| Event | Tag pattern | Example |
+|-------|-------------|---------|
+| Push to `main` | `main-<sha>` | `main-a1b2c3d` |
+| Tag `v1.2.3` | `1.2.3`, `1.2`, `latest` | `1.2.3` |
+| Pull request | `pr-<number>` | `pr-42` |
+
+Images are published to `ghcr.io/cchinchilla-dev/agentloom`.
+
+## Security
+
+All workloads enforce the Kubernetes **Pod Security Standards "restricted" profile**:
+
+- :material-account-lock: **Non-root container** — runs as `agentloom` (UID 1000), enforced via Dockerfile and `securityContext.runAsNonRoot`
+- :material-file-lock: **Read-only root filesystem** — `readOnlyRootFilesystem: true` with writable `/tmp` via `emptyDir`
+- :material-shield-lock: **No privilege escalation** — `allowPrivilegeEscalation: false`, all Linux capabilities dropped
+- :material-lock-outline: **seccomp** — `RuntimeDefault` profile blocks dangerous syscalls
+- :material-key-remove: **No API server access** — `automountServiceAccountToken: false`
+- :material-web-off: **NetworkPolicy** — restricts egress to DNS (kube-system), HTTPS (443), and OTel (4317). Production removes Ollama (11434). All ingress denied
+- :material-shield-key: **Secrets management** — API keys stored in K8s Secrets, never baked into images
+- :material-pin: **Supply chain security** — all GitHub Actions pinned to commit SHAs, not mutable tags
+- :material-gauge: **ResourceQuota** — optional namespace-level limits to prevent resource exhaustion
+- :material-label: **PSS namespace labels** — `pod-security.kubernetes.io/enforce: restricted`

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,243 @@
+# Examples
+
+27 example workflows covering basic patterns to production-grade pipelines. All examples run with Ollama (free, local) or any cloud provider.
+
+```bash
+# Validate any example
+agentloom validate examples/01_simple_qa.yaml
+
+# Run with Ollama
+agentloom run examples/01_simple_qa.yaml --provider ollama --model phi4
+
+# Run with OpenAI
+export OPENAI_API_KEY=sk-...
+agentloom run examples/02_chain_of_thought.yaml
+
+# Visualize the DAG
+agentloom visualize examples/03_router_workflow.yaml
+agentloom visualize examples/03_router_workflow.yaml --format mermaid
+```
+
+---
+
+## Basic
+
+### 01 — Simple QA
+
+Single LLM call. Sends a question, gets an answer.
+
+**Demonstrates:** basic workflow structure, state, output mapping.
+
+```yaml
+name: simple-qa
+config:
+  provider: ollama
+  model: phi4
+state:
+  question: "What is Python in one sentence?"
+steps:
+  - id: answer
+    type: llm_call
+    prompt: "Answer this question concisely: {state.question}"
+    output: answer
+```
+
+### 02 — Chain of Thought
+
+Three sequential LLM calls: break down topic, research subtopics, synthesize summary.
+
+**Demonstrates:** sequential dependencies, state passing between steps.
+
+### 03 — Customer Support Router
+
+Classifies user intent, routes to specialized handler (billing/technical/general).
+
+**Demonstrates:** `router` step, conditional branching — only one branch executes.
+
+### 04 — Tool Augmented
+
+Fetches data from a URL using the `http_request` tool, then analyzes it with an LLM.
+
+**Demonstrates:** tool integration, mixing `tool` and `llm_call` steps.
+
+---
+
+## Intermediate
+
+### 05 — Content Moderation Pipeline
+
+Parallel content moderation for UGC platforms. Runs toxicity, PII, and policy checks simultaneously, aggregates results, and routes to approve/review/reject.
+
+**Demonstrates:** parallel execution (3 checks at once), aggregation, router with 3 branches.
+
+### 06 — Lead Qualification
+
+B2B lead qualification pipeline. Enriches company data via API, analyzes buying intent, scores the lead, and routes to personalized outreach, nurture, or archive.
+
+**Demonstrates:** parallel tool+LLM execution, multi-step scoring, conditional routing.
+
+### 07 — Incident Triage
+
+Automated incident triage for SRE teams. Fetches deployment context, correlates with alert data, classifies severity (P1/P2/P3), and generates response actions.
+
+**Demonstrates:** 5-layer deep pipeline, tool integration, severity-based routing.
+
+### 08 — Contract Risk Analysis
+
+Legal contract risk analysis. Extracts clauses, evaluates risk, compares against industry standards, and generates an executive summary with sign/negotiate/walk-away recommendation.
+
+**Demonstrates:** deep 4-step sequential chain, state accumulation, structured analysis.
+
+---
+
+## Advanced
+
+### 09 — Fraud Detection Pipeline
+
+E-commerce order fraud detection. Fetches order + customer data in parallel, runs 4 concurrent fraud signal checks (velocity, amount, address, device), aggregates risk, and routes high-risk orders to a deep investigation subworkflow.
+
+**Demonstrates:** 2 parallel tools, 4 parallel LLM checks, subworkflow, 11 steps / 5 layers.
+
+### 10 — Multi-Market Content Localization
+
+SaaS content localization across 3 markets. Fetches source content, runs 3 parallel localization subworkflows (ES/DE/JA) — each with 4 steps: translate, culturally adapt, legal compliance, and format — then cross-market review and deployment manifest.
+
+**Demonstrates:** 3 parallel subworkflows (12 nested steps), 18 total steps across 4 layers.
+
+### 11 — Insurance Claims Processing
+
+End-to-end claims adjudication. Extracts structured data, runs 3 parallel validation tracks via subworkflows (coverage, fraud, medical necessity), aggregates results, routes to auto-approve, adjuster assignment, or denial.
+
+**Demonstrates:** 4 subworkflows, 6 layers, 21 total steps. The most complex example.
+
+---
+
+## Built-in Tools
+
+### 12 — Log Analysis & Alerting
+
+Server log analysis with `shell_command` tool. Collects error logs and system metrics in parallel, correlates them with an LLM, classifies severity, and routes to PagerDuty alert, ops ticket, or silent log.
+
+**Demonstrates:** `shell_command` tool, parallel data collection, severity routing.
+
+### 13 — Report Generator
+
+Data pipeline health report using `file_read` and `file_write` tools. Reads pipeline results and SLA config, analyzes compliance, generates executive summary, and writes the final report to disk.
+
+**Demonstrates:** `file_write` + `file_read` tools, file-based data pipeline.
+
+### 14 — Custom Tools: @tool Decorator
+
+Sentiment monitoring pipeline with custom tools defined using the `@tool` decorator: `query_database`, `send_slack_message`, `create_ticket`.
+
+**Demonstrates:** `@tool` decorator, custom tool registration.
+
+```bash
+uv run python examples/14_custom_tools_decorator.py
+```
+
+!!! info "Two files"
+    This example uses a paired YAML workflow + Python runner:
+    `14_custom_tools_decorator.yaml` + `14_custom_tools_decorator.py`
+
+### 15 — Custom Tools: BaseTool Subclass
+
+Customer data enrichment with custom tools defined as `BaseTool` subclasses: `GeocodingTool`, `CRMLookupTool`, `RiskScoreTool`.
+
+**Demonstrates:** `BaseTool` subclass pattern, churn risk scoring.
+
+```bash
+uv run python examples/15_custom_tools_subclass.py
+```
+
+---
+
+## Resilience & Sandbox
+
+### 16 — Circuit Breaker Demo
+
+Intentionally trips the circuit breaker with a non-existent model, then shows automatic fallback.
+
+**Demonstrates:** circuit breaker state transitions (CLOSED -> OPEN), provider fallback.
+
+### 17 — Sandbox: Allowed Operations
+
+Runs commands and file I/O within sandbox limits. `echo` is allowed, files stay inside `/tmp/agentloom`, network is enabled.
+
+**Demonstrates:** `config.sandbox`, command allowlist, path restriction.
+
+### 18 — Sandbox: Blocked Operations
+
+Attempts operations that violate sandbox policy: disallowed command (`curl`), path outside allowed directory, network disabled, and pipe injection (`echo | cat`).
+
+**Demonstrates:** sandbox enforcement, command injection prevention, path and network blocking.
+
+---
+
+## Multi-modal
+
+### 19 — URL Image
+
+Fetches an image from a public URL and describes it. The engine downloads the image locally and sends base64 to the provider (`fetch: local`).
+
+**Demonstrates:** `attachments`, URL fetch, multi-step vision pipeline.
+
+### 20 — Base64 Inline
+
+Analyzes an image embedded directly in workflow state as base64. No network access needed.
+
+**Demonstrates:** inline base64 attachment, offline-capable vision.
+
+### 21 — URL Passthrough
+
+Sends the image URL directly to the provider API (`fetch: provider`). Only works with OpenAI and Anthropic.
+
+**Demonstrates:** `fetch: provider` mode, provider-side image fetching.
+
+### 22 — Sandboxed URL
+
+Image analysis with sandbox restrictions. Only domains in `allowed_domains` are permitted.
+
+**Demonstrates:** sandbox `allowed_domains` for attachments.
+
+### 23 — PDF Document
+
+Extracts key points from a PDF and generates an executive summary. Requires Anthropic or Google.
+
+**Demonstrates:** `type: pdf` attachment, document analysis.
+
+### 24 — Audio Transcription
+
+Transcribes an audio clip and analyzes for topic, sentiment, and action items. Requires OpenAI or Google.
+
+**Demonstrates:** `type: audio` attachment, transcription + analysis pipeline.
+
+---
+
+## Streaming
+
+### 25 — Streaming QA
+
+Streams LLM output token-by-token in real-time.
+
+**Demonstrates:** `stream` config, `--stream` CLI flag, time-to-first-token tracking.
+
+```bash
+agentloom run examples/25_streaming_qa.yaml --stream
+```
+
+### 26 — Streaming + Multi-modal
+
+Combines streaming with image input. The image is fetched locally, and the LLM description is streamed back in real-time.
+
+**Demonstrates:** streaming + attachments composability.
+
+---
+
+## State Features
+
+### 27 — Array Index
+
+Array index support in state paths (`state.items[0]`, `items[0].name`, `results[-1]`).
+
+**Demonstrates:** bracket-based array indexing in state and templates.

--- a/docs/graph-api.md
+++ b/docs/graph-api.md
@@ -1,0 +1,147 @@
+# Graph API
+
+Programmatic access to the workflow DAG for analysis, visualization, and test coverage.
+
+## Quick start
+
+```python
+from agentloom import WorkflowGraph
+from agentloom.core.parser import WorkflowParser
+
+workflow = WorkflowParser.from_yaml("examples/03_router_workflow.yaml")
+graph = WorkflowGraph.from_workflow(workflow)
+```
+
+You can also build a graph from a bare `DAG` object (without a full workflow definition):
+
+```python
+from agentloom.core.dag import DAG
+from agentloom.core.graph import WorkflowGraph
+
+dag = DAG()
+dag.add_node("a")
+dag.add_node("b")
+dag.add_edge("a", "b")
+graph = WorkflowGraph.from_dag(dag)
+```
+
+## Data models
+
+### GraphNode
+
+Frozen Pydantic model representing a step in the graph:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `str` | Step identifier |
+| `type` | `str` | Step type (`llm_call`, `tool`, `router`, `subworkflow`) |
+| `depends_on` | `list[str]` | IDs of predecessor steps |
+| `label` | `str` | Display label |
+
+### GraphEdge
+
+Frozen Pydantic model representing a dependency edge:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `source` | `str` | Source step ID |
+| `target` | `str` | Target step ID |
+| `label` | `str` | Edge label (e.g., router condition) |
+
+## Properties
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `graph.nodes` | `list[GraphNode]` | Nodes in topological order |
+| `graph.edges` | `list[GraphEdge]` | Edges sorted by (source, target) |
+| `graph.roots` | `list[str]` | Entry-point step IDs (no predecessors) |
+| `graph.leaves` | `list[str]` | Terminal step IDs (no successors) |
+| `graph.layers` | `list[list[str]]` | Steps grouped into parallel-execution layers |
+
+## Analysis methods
+
+### `critical_path()`
+
+Returns the longest path by hop count — the latency bottleneck:
+
+```python
+graph.critical_path()
+# ["fetch_data", "analyze", "summarize", "report"]
+```
+
+### `all_paths()`
+
+Every simple path from root to leaf:
+
+```python
+for path in graph.all_paths():
+    print(" -> ".join(path))
+# fetch_data -> analyze -> report
+# fetch_data -> analyze -> summarize -> report
+```
+
+### `prime_paths()`
+
+Maximal simple paths for test coverage. These are paths that cannot be extended without repeating a node:
+
+```python
+graph.prime_paths(max_paths=10000)
+```
+
+### `get_step_definition(node_id)`
+
+Retrieve the original step config for a node:
+
+```python
+step = graph.get_step_definition("classify")
+# StepDefinition(id="classify", type="llm_call", ...)
+```
+
+## Export formats
+
+=== "Graphviz DOT"
+
+    ```python
+    dot = graph.to_dot()
+    with open("workflow.dot", "w") as f:
+        f.write(dot)
+    # Then: dot -Tpng workflow.dot -o workflow.png
+    ```
+
+    Node shapes by step type: rounded box (LLM), trapezium (tool), diamond (router), doubleoctagon (subworkflow).
+
+=== "Mermaid"
+
+    ```python
+    mermaid = graph.to_mermaid()
+    # Paste into https://mermaid.live or use in docs
+    ```
+
+    Generates `graph TD` format with edge labels for router conditions.
+
+=== "PNML"
+
+    ```python
+    pnml = graph.to_pnml()
+    # Petri Net Markup Language (places + transitions)
+    ```
+
+=== "Dict (JSON)"
+
+    ```python
+    data = graph.to_dict()
+    # {"nodes": [...], "edges": [...], "roots": [...], "leaves": [...],
+    #  "layers": [...], "critical_path": [...]}
+    ```
+
+=== "NetworkX"
+
+    ```bash
+    pip install agentloom[graph]
+    ```
+
+    ```python
+    nx_graph = graph.to_networkx()  # networkx.DiGraph
+    # Nodes have "type" and "label" attributes
+    # Edges have "label" attribute
+    ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,130 @@
+---
+hide:
+  - navigation
+---
+
+# AgentLoom
+
+**Deterministic LLM workflow orchestration with native observability, resilience, and cost control.**
+
+---
+
+<div class="grid cards" markdown>
+
+-   :material-graph-outline:{ .lg .middle } **DAG-based workflows**
+
+    ---
+
+    Define workflows as directed acyclic graphs in YAML or Python. Steps, dependencies, and routing are declared upfront — the LLM generates text, not control flow.
+
+-   :material-eye-outline:{ .lg .middle } **Native observability**
+
+    ---
+
+    OpenTelemetry traces and Prometheus metrics on every step. Grafana dashboards included. No external SaaS required.
+
+-   :material-shield-check-outline:{ .lg .middle } **Built-in resilience**
+
+    ---
+
+    Circuit breakers, rate limiters, and automatic multi-provider fallback. If OpenAI is down, the gateway falls back to Anthropic or Ollama.
+
+-   :material-currency-usd:{ .lg .middle } **Cost control**
+
+    ---
+
+    Per-workflow budget limits, token tracking, and cost estimation across all providers. A workflow with `budget_usd: 0.50` cannot overspend.
+
+</div>
+
+---
+
+## Installation
+
+=== "Core"
+
+    ```bash
+    pip install agentloom
+    ```
+
+=== "With observability"
+
+    ```bash
+    pip install agentloom[all]
+    ```
+
+=== "With graph analysis"
+
+    ```bash
+    pip install agentloom[graph]
+    ```
+
+## Quick start
+
+**1. Create a workflow** — `my_workflow.yaml`:
+
+```yaml
+name: simple-qa
+config:
+  provider: openai
+  model: gpt-4o-mini
+
+state:
+  question: "What is Python in one sentence?"
+
+steps:
+  - id: answer
+    type: llm_call
+    prompt: "Answer this question concisely: {state.question}"
+    output: answer
+```
+
+**2. Run it:**
+
+=== "OpenAI"
+
+    ```bash
+    export OPENAI_API_KEY=sk-...
+    agentloom run my_workflow.yaml
+    ```
+
+=== "Ollama (free, local)"
+
+    ```bash
+    agentloom run my_workflow.yaml --provider ollama --model phi4
+    ```
+
+=== "Anthropic"
+
+    ```bash
+    export ANTHROPIC_API_KEY=sk-ant-...
+    agentloom run my_workflow.yaml --provider anthropic --model claude-sonnet-4-20250514
+    ```
+
+=== "Google"
+
+    ```bash
+    export GOOGLE_API_KEY=...
+    agentloom run my_workflow.yaml --provider google --model gemini-2.5-flash
+    ```
+
+**3. Validate and visualize:**
+
+```bash
+agentloom validate my_workflow.yaml    # check for errors
+agentloom visualize my_workflow.yaml   # render the DAG
+```
+
+## What's next
+
+| Section | Description |
+|---------|-------------|
+| [Architecture](architecture.md) | Execution engine, DAG scheduler, state management |
+| [Providers](providers.md) | Supported providers, models, and multi-modal capabilities |
+| [Workflow YAML](workflow-yaml.md) | Full reference for step types, config, routing, and attachments |
+| [Python DSL](python-dsl.md) | Build workflows programmatically |
+| [Graph API](graph-api.md) | Analyze, visualize, and export workflow DAGs |
+| [Observability](observability.md) | Traces, metrics, and Grafana dashboards |
+| [Examples](examples.md) | 27 example workflows from basic to production-grade |
+| [Deployment](deployment.md) | Docker, Kubernetes, Helm, Terraform, and ArgoCD |
+| [Changelog](changelog.md) | Version history and release notes |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,224 @@
+# Observability
+
+Every workflow step emits OpenTelemetry traces and Prometheus metrics out of the box. No external SaaS required — the full stack runs alongside your workloads.
+
+## Quick start
+
+```bash
+# Start the observability stack
+cd deploy && docker compose up -d
+
+# Run a workflow (metrics are emitted automatically)
+agentloom run examples/01_simple_qa.yaml
+
+# Access dashboards
+open http://localhost:3000    # Grafana (admin/admin)
+open http://localhost:9090    # Prometheus
+open http://localhost:16686   # Jaeger
+```
+
+## Stack architecture
+
+```
+CLI (agentloom run)
+  |
+  +-- OTel SDK --> OTel Collector (:4317 gRPC)
+  |                    |
+  |                    +-- Prometheus exporter (:8889) --> Prometheus (:9090)
+  |                    +-- OTLP exporter --> Jaeger (:16686)
+  |
+  +-- Observer --> MetricsManager --> OTel gauges / counters / histograms
+```
+
+Each CLI invocation is an ephemeral process that creates its own `MeterProvider`. The OTel Collector aggregates metrics and exposes them to Prometheus with a 30-minute expiration window (`metric_expiration: 30m`), so data remains visible after the CLI exits.
+
+| Component | Port | Purpose |
+|-----------|------|---------|
+| OTel Collector | 4317 (gRPC), 8889 (Prometheus) | Receives OTel data, exports to Prometheus + Jaeger |
+| Prometheus | 9090 | Time-series storage, PromQL queries |
+| Jaeger | 16686 | Distributed tracing UI |
+| Grafana | 3000 | Dashboard visualization |
+
+---
+
+## Grafana dashboard
+
+The dashboard is auto-provisioned at startup. Navigate to **Dashboards > AgentLoom** or go directly to `http://localhost:3000/d/agentloom-main`.
+
+### Dashboard variables
+
+Use the dropdown selectors at the top of the dashboard to filter:
+
+| Variable | Label | Default | Description |
+|----------|-------|---------|-------------|
+| `$workflow` | Workflow | `.*` | Filter panels by workflow name |
+| `$provider` | Provider | `.*` | Filter panels by provider |
+
+### Row 1 — Overview
+
+Seven stat panels showing high-level aggregates:
+
+| Panel | Type | What it shows |
+|-------|------|---------------|
+| **Total Runs** | stat | Total workflow executions across all workflows |
+| **Success Rate** | gauge | Percentage of successful runs (green >= 95%, orange >= 80%, red < 80%) |
+| **Failed** | stat | Count of failed workflow runs |
+| **Total Tokens** | stat | Sum of all tokens consumed (input + output) |
+| **Est. Cost** | stat | Estimated total cost in USD |
+| **Providers** | stat | Number of distinct providers that have handled requests |
+| **Step Types** | stat | Number of distinct step types executed |
+
+### Row 2 — Workflow Performance
+
+| Panel | Type | What it shows |
+|-------|------|---------------|
+| **Workflow Runs** | timeseries | Cumulative success vs failed runs over time |
+| **Workflow Duration (p50/p95/p99)** | timeseries | Latency percentiles per workflow |
+
+### Row 3 — Step Analysis
+
+| Panel | Type | What it shows |
+|-------|------|---------------|
+| **Step Executions** | timeseries | Cumulative step success vs failure count over time |
+| **Step Duration (p50/p95/p99)** | timeseries | Per-step-type latency percentiles |
+
+### Row 4 — Token Economics
+
+| Panel | Type | What it shows |
+|-------|------|---------------|
+| **Tokens** | timeseries | Cumulative input vs output token count per provider/model |
+| **Tokens by Provider** | bar gauge | Horizontal bars showing total tokens per provider/model |
+| **Token Split** | pie chart | Ratio of prompt tokens to completion tokens |
+
+### Row 5 — Provider Performance
+
+| Panel | Type | What it shows |
+|-------|------|---------------|
+| **Provider Latency (p50/p95/p99)** | timeseries | Per-provider response time percentiles |
+| **Provider Calls** | timeseries | Cumulative call count per provider |
+
+### Row 6 — Provider Reliability
+
+| Panel | Type | What it shows |
+|-------|------|---------------|
+| **Provider Errors** | timeseries | Cumulative error count per provider |
+| **Provider Availability** | gauge | Uptime percentage over last hour (green >= 99%, orange >= 95%, red < 95%) |
+| **Circuit Breaker** | stat | Current circuit breaker state per provider |
+
+??? info "Circuit breaker state values"
+
+    | Value | Label | Color | Meaning |
+    |-------|-------|-------|---------|
+    | 0 | CLOSED | Green | Normal — requests pass through |
+    | 1 | OPEN | Red | Tripped — requests rejected immediately |
+    | 2 | HALF-OPEN | Yellow | Recovery probe — one test request allowed |
+
+    State transitions: CLOSED -> OPEN after 5 consecutive failures. OPEN -> HALF-OPEN after 60s timeout. HALF-OPEN -> CLOSED on success, back to OPEN on failure.
+
+### Row 7 — Detailed Breakdown
+
+| Panel | Type | What it shows |
+|-------|------|---------------|
+| **Workflow Runs Summary** | table | Per-workflow, per-status run counts |
+| **Provider Call Details** | table | Per-provider, per-model call counts |
+
+### Row 8 — Cost Analysis
+
+| Panel | Type | What it shows |
+|-------|------|---------------|
+| **Cumulative Cost** | timeseries | Running total cost in USD |
+| **Token Cost** | timeseries | Estimated cost based on cumulative token volume per provider/model |
+| **Budget Remaining** | timeseries | Remaining budget per workflow (green line) |
+| **Avg Cost/Run** | stat | Mean cost per workflow execution |
+| **Avg Tokens/Run** | stat | Mean token consumption per workflow execution |
+| **Avg Duration/Run** | stat | Mean wall-clock time per workflow execution |
+| **Token Input/Output Ratio** | stat | Ratio of output tokens to input tokens |
+
+### Row 9 — Multi-modal
+
+| Panel | Type | What it shows |
+|-------|------|---------------|
+| **Attachments** | timeseries | Attachment count by type (image, pdf, audio) |
+
+### Row 10 — Streaming
+
+| Panel | Type | What it shows |
+|-------|------|---------------|
+| **Stream Responses** | timeseries | Cumulative streaming response count |
+| **Time to First Token (p50/p95/p99)** | timeseries | TTFT latency percentiles |
+
+---
+
+## Metrics reference
+
+All metrics are prefixed with `agentloom_`.
+
+### Workflow metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `workflow_runs_total` | counter | workflow, status | Workflow execution count |
+| `workflow_duration_seconds` | histogram | workflow | End-to-end workflow latency |
+| `cost_usd_total` | counter | — | Estimated USD cost |
+| `budget_remaining_usd` | gauge | workflow | Remaining budget per workflow |
+
+### Step metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `step_executions_total` | counter | step_type, status, stream | Step execution count |
+| `step_duration_seconds` | histogram | step_type, stream | Per-step latency |
+
+### Provider metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `provider_calls_total` | counter | provider, model, stream | Provider API call count |
+| `provider_latency_seconds` | histogram | provider, model, stream | Provider response latency |
+| `provider_errors_total` | counter | provider, error_type | Provider error count |
+| `circuit_breaker_state` | gauge | provider | Circuit breaker state (0/1/2) |
+
+### Token metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `tokens_total` | counter | provider, model, direction | Token usage (input/output) |
+| `attachments_total` | counter | step_type | Attachment count by step type |
+
+### Streaming metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `stream_responses_total` | counter | provider, model | Streaming response count |
+| `time_to_first_token_seconds` | histogram | provider, model | Time to first token latency |
+
+---
+
+## Troubleshooting
+
+??? question "Panels show 'No data'"
+    Metrics are ephemeral — each CLI run exports data, then the process exits. The OTel Collector retains metrics for 30 minutes (`metric_expiration`).
+
+    ```bash
+    # Verify metrics reach Prometheus
+    curl -s 'http://localhost:9090/api/v1/query?query=agentloom_workflow_runs_total'
+
+    # Run a workflow to generate fresh data
+    agentloom run examples/01_simple_qa.yaml
+
+    # Run the circuit breaker demo for reliability panels
+    agentloom run examples/16_circuit_breaker_demo.yaml
+    ```
+
+??? question "Timeseries panels show flat lines"
+    Each CLI invocation is a short-lived process that creates ephemeral counters. Timeseries panels show cumulative totals — run several workflows to see the values increase over time. Metrics expire from Prometheus after 30 minutes, so run workflows periodically.
+
+??? question "Circuit Breaker shows OPEN unexpectedly"
+    If you ran `16_circuit_breaker_demo.yaml`, it intentionally trips the circuit breaker with a non-existent model. The OPEN state persists in Prometheus for 30 minutes. Run a successful workflow against the same provider to reset it, or wait for the metric to expire.
+
+??? question "Traces not appearing in Jaeger"
+    Check that the OTel Collector is running and accepting gRPC on port 4317:
+    ```bash
+    docker compose ps
+    docker compose logs otel-collector
+    ```

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,112 @@
+# Providers
+
+AgentLoom ships with four providers. The gateway routes requests based on model name and falls back automatically when a provider is unavailable.
+
+## Capability matrix
+
+| Capability | OpenAI | Anthropic | Google | Ollama |
+|---|---|---|---|---|
+| Models | `gpt-*`, `o3*`, `o4*` | `claude*` | `gemini*` | Any local model |
+| Streaming | SSE | SSE | SSE | NDJSON |
+| Image input | :material-check: | :material-check: | :material-check: | :material-check: |
+| PDF input | :material-close: | :material-check: | :material-check: | :material-close: |
+| Audio input | :material-check: | :material-close: | :material-check: | :material-close: |
+| Cost tracking | :material-check: | :material-check: | :material-check: | Free (local) |
+
+## Configuration
+
+Switch provider in any workflow:
+
+```yaml
+config:
+  provider: google
+  model: gemini-2.5-flash
+```
+
+Or override at runtime via CLI:
+
+```bash
+agentloom run workflow.yaml --provider anthropic --model claude-sonnet-4-20250514
+```
+
+## Environment variables
+
+| Variable | Provider |
+|----------|----------|
+| `OPENAI_API_KEY` | OpenAI |
+| `ANTHROPIC_API_KEY` | Anthropic |
+| `GOOGLE_API_KEY` | Google |
+| `OLLAMA_BASE_URL` | Ollama (default: `http://localhost:11434`) |
+
+## Circuit breaker
+
+The gateway wraps each provider with a circuit breaker:
+
+| State | Behavior | Transition |
+|-------|----------|------------|
+| **Closed** | Requests pass through normally | :material-arrow-right: Open after 5 consecutive failures |
+| **Open** | Requests rejected immediately, fallback provider used | :material-arrow-right: Half-open after 60s |
+| **Half-open** | One test request allowed | :material-arrow-right: Closed on success, Open on failure |
+
+## Rate limiter
+
+Dual token-bucket rate limiting per provider:
+
+- **Requests per minute** — default 60 RPM
+- **Tokens per minute** — default 100,000 TPM
+
+```python
+gateway.register(
+    provider,
+    max_rpm=120,          # requests/minute
+    max_tpm=200_000,      # tokens/minute
+)
+```
+
+## Fallback chain
+
+Providers are tried in priority order. Register multiple providers for automatic fallback:
+
+```python
+gateway.register(openai_provider, priority=0)
+gateway.register(anthropic_provider, priority=1, is_fallback=True)
+gateway.register(ollama_provider, priority=2, is_fallback=True)
+```
+
+If OpenAI fails or its circuit breaker trips, the gateway automatically routes to Anthropic. If Anthropic also fails, it falls back to Ollama.
+
+## Multi-modal attachments
+
+LLM steps support image, PDF, and audio attachments:
+
+```yaml
+steps:
+  - id: analyze
+    type: llm_call
+    prompt: "Describe what you see in this image."
+    attachments:
+      - type: image
+        source: "{state.image_url}"
+        fetch: local
+    output: description
+```
+
+| Field | Description |
+|-------|-------------|
+| `type` | `image`, `pdf`, or `audio` |
+| `source` | URL, local file path, or base64 data |
+| `media_type` | Optional; inferred from type if omitted |
+| `fetch` | `local` (engine downloads) or `provider` (provider fetches URL directly) |
+
+!!! warning "Provider support varies"
+    Check the [capability matrix](#capability-matrix) above. Sending a PDF to OpenAI or audio to Anthropic will raise a `ProviderError`.
+
+## Security
+
+### SSRF protection
+
+URL-based attachments (`fetch: local`) are protected against Server-Side Request Forgery. The engine blocks requests to private and reserved IP ranges (RFC 1918, loopback, link-local) before any network call is made.
+
+### Attachment size limit
+
+All attachments are limited to **20 MB** per file. Larger files are rejected before being sent to the provider.

--- a/docs/python-dsl.md
+++ b/docs/python-dsl.md
@@ -1,0 +1,176 @@
+# Python DSL
+
+Build workflows programmatically with a fluent builder API.
+
+## Basic usage
+
+```python
+from agentloom.core.dsl import workflow
+
+wf = (
+    workflow("simple-qa", provider="ollama", model="phi4")
+    .set_state(question="What is Python?")
+    .add_llm_step("answer", prompt="Answer: {question}", output="answer")
+    .build()
+)
+```
+
+The `workflow()` function returns a `WorkflowBuilder`. All methods return `self` for chaining. Call `.build()` to validate and produce a `WorkflowDefinition`.
+
+## API reference
+
+### `workflow()`
+
+```python
+workflow(name: str, description: str = "", **config_kwargs) -> WorkflowBuilder
+```
+
+Factory function. Config keyword arguments map to [workflow config options](workflow-yaml.md#config-options):
+
+```python
+wf = workflow(
+    "my-workflow",
+    provider="openai",
+    model="gpt-4o-mini",
+    budget_usd=0.50,
+    stream=True,
+)
+```
+
+### `.set_state(**kwargs)`
+
+Initialize workflow state variables:
+
+```python
+.set_state(
+    question="What is Python?",
+    context="",
+    items=[{"id": 1, "name": "Item A"}],
+)
+```
+
+### `.add_llm_step()`
+
+```python
+.add_llm_step(
+    step_id: str,
+    prompt: str,
+    system_prompt: str | None = None,
+    model: str | None = None,           # override workflow model
+    output: str | None = None,
+    depends_on: list[str] | None = None,
+    attachments: list[Attachment] | None = None,
+    stream: bool | None = None,
+    **kwargs,                           # temperature, max_tokens, timeout, retry, etc.
+)
+```
+
+### `.add_tool_step()`
+
+```python
+.add_tool_step(
+    step_id: str,
+    tool_name: str,
+    tool_args: dict[str, Any] | None = None,
+    output: str | None = None,
+    depends_on: list[str] | None = None,
+)
+```
+
+### `.add_router_step()`
+
+```python
+.add_router_step(
+    step_id: str,
+    conditions: list[tuple[str, str]],   # (expression, target) pairs
+    default: str | None = None,
+    depends_on: list[str] | None = None,
+)
+```
+
+### `.add_subworkflow_step()`
+
+```python
+.add_subworkflow_step(
+    step_id: str,
+    workflow_path: str | None = None,
+    workflow_inline: dict[str, Any] | None = None,
+    output: str | None = None,
+    depends_on: list[str] | None = None,
+)
+```
+
+### `.build()`
+
+Validates the workflow definition (checks for cycles, missing dependencies, etc.) and returns a `WorkflowDefinition`.
+
+---
+
+## Full example
+
+A multi-step customer support workflow:
+
+```python
+from agentloom.core.dsl import workflow
+
+wf = (
+    workflow(
+        "customer-support",
+        provider="openai",
+        model="gpt-4o-mini",
+        budget_usd=0.10,
+    )
+    .set_state(
+        user_message="My order arrived damaged",
+        classification="",
+        response="",
+    )
+    .add_llm_step(
+        "classify",
+        system_prompt="Respond with one word: billing, technical, or general.",
+        prompt="Classify: {state.user_message}",
+        output="classification",
+    )
+    .add_router_step(
+        "route",
+        depends_on=["classify"],
+        conditions=[
+            ("state.classification.strip().lower() == 'billing'", "handle_billing"),
+            ("state.classification.strip().lower() == 'technical'", "handle_technical"),
+        ],
+        default="handle_general",
+    )
+    .add_llm_step(
+        "handle_billing",
+        depends_on=["route"],
+        prompt="Help with billing issue: {state.user_message}",
+        output="response",
+    )
+    .add_llm_step(
+        "handle_technical",
+        depends_on=["route"],
+        prompt="Help with technical issue: {state.user_message}",
+        output="response",
+    )
+    .add_llm_step(
+        "handle_general",
+        depends_on=["route"],
+        prompt="Help with: {state.user_message}",
+        output="response",
+    )
+    .build()
+)
+```
+
+## Running a built workflow
+
+```python
+from agentloom.core.engine import WorkflowEngine
+
+engine = WorkflowEngine(wf)
+result = await engine.run()
+
+print(result.status)            # success
+print(result.final_state)       # {"user_message": "...", "response": "..."}
+print(result.total_cost_usd)    # 0.002
+```

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,11 @@
+.md-typeset .grid.cards > ul > li {
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.md-typeset .grid.cards > ul > li:hover {
+    border-color: var(--md-accent-fg-color);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}

--- a/docs/workflow-yaml.md
+++ b/docs/workflow-yaml.md
@@ -1,0 +1,295 @@
+# Workflow YAML Reference
+
+Complete reference for workflow definition files.
+
+## Top-level structure
+
+```yaml
+name: my-workflow                           # required
+version: "1.0"                              # optional, default "1.0"
+description: "What this workflow does"      # optional
+
+config:
+  provider: openai                          # default provider
+  model: gpt-4o-mini                        # default model
+  max_retries: 3                            # retry attempts per step
+  budget_usd: 0.50                          # spending limit (null = unlimited)
+  timeout: 300.0                            # workflow timeout in seconds (null = unlimited)
+  max_concurrent_steps: 10                  # parallel step limit
+  stream: false                             # streaming default
+
+state:
+  key: "value"                              # initial state variables
+  nested:
+    key: "value"
+
+steps:                                      # at least one step required
+  - id: step_id
+    type: llm_call                          # llm_call | tool | router | subworkflow
+    # ... step-specific fields
+```
+
+## Config options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `provider` | `string` | `openai` | Default LLM provider |
+| `model` | `string` | `gpt-4o-mini` | Default model for all LLM steps |
+| `max_retries` | `int` | `3` | Retry attempts on failure |
+| `budget_usd` | `float` | `null` | Maximum spend in USD |
+| `timeout` | `float` | `null` | Workflow timeout in seconds |
+| `max_concurrent_steps` | `int` | `10` | Max parallel steps per layer |
+| `stream` | `bool` | `false` | Enable streaming by default |
+| `sandbox` | `object` | disabled | Security sandbox config |
+
+## State
+
+State variables are initialized in the `state` block and accessible in templates:
+
+```yaml
+state:
+  question: "What is Python?"
+  items:
+    - id: 1
+      name: "Item A"
+  count: 42
+```
+
+**Template syntax:**
+
+| Expression | Result |
+|------------|--------|
+| `{state.question}` | `"What is Python?"` |
+| `{question}` | `"What is Python?"` (flat access) |
+| `{state.items[0].name}` | `"Item A"` |
+| `{state.count}` | `42` |
+
+Steps with `output: key` update `state[key]` after execution.
+
+---
+
+## Step types
+
+### `llm_call`
+
+Sends a prompt to an LLM and stores the response.
+
+```yaml
+- id: answer
+  type: llm_call
+  prompt: "Answer: {state.question}"        # required
+  system_prompt: "You are helpful."         # optional
+  model: gpt-4o                             # optional, overrides config
+  temperature: 0.7                          # optional (0-2)
+  max_tokens: 1000                          # optional
+  stream: true                              # optional, overrides config
+  output: answer                            # state key for result
+  timeout: 30.0                             # per-step timeout
+  depends_on: [previous_step]               # dependencies
+  attachments:                              # multi-modal input
+    - type: image
+      source: "{state.image_url}"
+      fetch: local
+  retry:
+    max_retries: 3
+    backoff_base: 2.0
+    backoff_max: 60.0
+```
+
+**LLM step fields:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `prompt` | `string` | — | Required. Template string with `{state.*}` interpolation |
+| `system_prompt` | `string` | `null` | Optional system message |
+| `model` | `string` | `null` | Override workflow-level model |
+| `temperature` | `float` | `null` | Sampling temperature (0-2), provider default if null |
+| `max_tokens` | `int` | `null` | Output token limit |
+| `stream` | `bool` | `null` | Override workflow-level streaming setting |
+| `attachments` | `list[Attachment]` | `[]` | Multi-modal inputs (see [Providers](providers.md#multi-modal-attachments)) |
+| `output` | `string` | `null` | State key to store result |
+| `timeout` | `float` | `null` | Per-step timeout in seconds |
+| `depends_on` | `list[string]` | `[]` | Step IDs that must complete first |
+
+**Retry config:**
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_retries` | `int` | `3` | Number of retry attempts |
+| `backoff_base` | `float` | `2.0` | Exponential backoff base (wait = base^attempt) |
+| `backoff_max` | `float` | `60.0` | Maximum wait between retries in seconds |
+
+### `router`
+
+Evaluates conditions against state and activates a target step. Steps not activated are skipped.
+
+```yaml
+- id: route
+  type: router
+  depends_on: [classify]
+  conditions:
+    - expression: "state.classification == 'question'"
+      target: answer_question
+    - expression: "state.score > 80"
+      target: handle_high
+  default: handle_general                   # fallback if no condition matches
+```
+
+**Allowed in expressions:** comparisons, boolean operators (`and`, `or`, `not`), builtins (`len`, `str`, `int`, `float`, `bool`, `abs`, `min`, `max`).
+
+!!! warning "Safety"
+    Router expressions are validated via AST. No imports, no `exec`, no attribute assignment. Only a safe subset of Python is allowed.
+
+### `tool`
+
+Executes a registered tool (shell command, HTTP request, etc.).
+
+```yaml
+- id: fetch
+  type: tool
+  tool_name: http_request                   # registered tool name
+  tool_args:
+    url: "state.api_url"                    # "state." prefix resolves from state
+    method: "GET"
+    headers:
+      Authorization: "Bearer token"
+  output: response
+  depends_on: [previous_step]
+```
+
+!!! info "Argument resolution"
+    String values starting with `state.` are resolved from workflow state. Other values are passed as literals.
+
+### `subworkflow`
+
+Nests a workflow inside another. The child inherits the parent's state.
+
+=== "External file"
+
+    ```yaml
+    - id: nested
+      type: subworkflow
+      workflow_path: "./child_workflow.yaml"
+      output: child_result
+      depends_on: [prepare]
+    ```
+
+=== "Inline definition"
+
+    ```yaml
+    - id: nested
+      type: subworkflow
+      workflow_inline:
+        name: child
+        steps:
+          - id: inner
+            type: llm_call
+            prompt: "Process: {state.data}"
+            output: processed
+      output: child_result
+    ```
+
+---
+
+## Streaming
+
+Enable streaming at the workflow level, per-step, or via CLI:
+
+=== "Workflow config"
+
+    ```yaml
+    config:
+      stream: true
+    ```
+
+=== "Per-step"
+
+    ```yaml
+    steps:
+      - id: answer
+        type: llm_call
+        stream: true
+        prompt: "Answer: {question}"
+    ```
+
+=== "CLI flag"
+
+    ```bash
+    agentloom run workflow.yaml --stream
+    ```
+
+Token usage, cost, and time-to-first-token are tracked during streaming.
+
+---
+
+## Sandbox
+
+Restrict tool execution with an allowlist-based sandbox:
+
+```yaml
+config:
+  sandbox:
+    enabled: true
+    allowed_commands: [echo, cat, curl]
+    allowed_paths: [/tmp/work]
+    readable_paths: [/data]
+    writable_paths: [/tmp/output]
+    allow_network: true
+    allowed_domains: [api.example.com]
+    max_write_bytes: 1000000
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `enabled` | `bool` | Enable sandbox restrictions |
+| `allowed_commands` | `list[str]` | Shell command whitelist |
+| `allowed_paths` | `list[str]` | General file access paths |
+| `readable_paths` | `list[str]` | Read-only paths |
+| `writable_paths` | `list[str]` | Write-allowed paths |
+| `allow_network` | `bool` | Allow HTTP/network calls |
+| `allowed_domains` | `list[str]` | Domain whitelist |
+| `max_write_bytes` | `int` | Maximum file write size |
+
+---
+
+## Complete example
+
+A classify-and-respond workflow with routing:
+
+```yaml
+name: classify-and-respond
+config:
+  provider: openai
+  model: gpt-4o-mini
+  budget_usd: 0.50
+
+state:
+  user_input: ""
+
+steps:
+  - id: classify
+    type: llm_call
+    system_prompt: "Classify as: question, complaint, or request."
+    prompt: "Classify: {state.user_input}"
+    output: classification
+
+  - id: route
+    type: router
+    depends_on: [classify]
+    conditions:
+      - expression: "state.classification == 'question'"
+        target: answer
+    default: general_response
+
+  - id: answer
+    type: llm_call
+    depends_on: [route]
+    prompt: "Answer: {state.user_input}"
+    output: response
+
+  - id: general_response
+    type: llm_call
+    depends_on: [route]
+    prompt: "Help with: {state.user_input}"
+    output: response
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,72 @@
+site_name: AgentLoom
+site_url: https://cchinchilla-dev.github.io/agentloom/
+site_description: Deterministic LLM workflow orchestration with native observability, resilience, and cost control.
+repo_url: https://github.com/cchinchilla-dev/agentloom
+repo_name: cchinchilla-dev/agentloom
+
+theme:
+  name: material
+  logo: images/logo_transparecy.png
+  favicon: images/logo_transparecy.png
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - navigation.footer
+    - content.code.copy
+    - content.tabs.link
+    - search.suggest
+    - search.highlight
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - Getting Started: index.md
+  - Architecture: architecture.md
+  - Providers: providers.md
+  - Workflow YAML: workflow-yaml.md
+  - Python DSL: python-dsl.md
+  - Graph API: graph-api.md
+  - Examples: examples.md
+  - Observability: observability.md
+  - Deployment: deployment.md
+  - Contributing: contributing.md
+  - Changelog: changelog.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - toc:
+      permalink: true
+  - tables
+
+extra_css:
+  - stylesheets/extra.css

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ graph = ["networkx>=3.0"]
 all = ["agentloom[observability]", "agentloom[graph]"]
 
 [dependency-groups]
+docs = [
+    "mkdocs>=1.6,<2.0",
+    "mkdocs-material>=9.5",
+]
 dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.23",
@@ -56,7 +60,7 @@ agentloom = "agentloom.cli.main:app"
 
 [project.urls]
 Homepage = "https://github.com/cchinchilla-dev/agentloom"
-Documentation = "https://github.com/cchinchilla-dev/agentloom#readme"
+Documentation = "https://cchinchilla-dev.github.io/agentloom/"
 Repository = "https://github.com/cchinchilla-dev/agentloom"
 
 [tool.hatch.build.targets.wheel]

--- a/uv.lock
+++ b/uv.lock
@@ -48,6 +48,10 @@ dev = [
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
+docs = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -76,6 +80,10 @@ dev = [
     { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = ">=0.4" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
+]
+docs = [
+    { name = "mkdocs", specifier = ">=1.6,<2.0" },
+    { name = "mkdocs-material", specifier = ">=9.5" },
 ]
 
 [[package]]
@@ -107,6 +115,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
 ]
 
 [[package]]
@@ -360,6 +391,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
@@ -499,6 +542,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -572,6 +627,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -584,12 +648,164 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
 ]
 
 [[package]]
@@ -781,6 +997,15 @@ wheels = [
 ]
 
 [[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -969,6 +1194,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1009,6 +1247,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -1077,6 +1327,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]
@@ -1151,6 +1413,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -1274,6 +1545,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393, upload-time = "2024-11-01T14:06:31.756Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392, upload-time = "2024-11-01T14:06:32.99Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019, upload-time = "2024-11-01T14:06:34.963Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471, upload-time = "2024-11-01T14:06:37.745Z" },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449, upload-time = "2024-11-01T14:06:39.748Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054, upload-time = "2024-11-01T14:06:41.009Z" },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add mkdocs-material documentation site with 11 pages: getting started, architecture, providers, workflow YAML reference, Python DSL, graph API, examples (27 workflows), observability (full dashboard reference), deployment (Docker/K8s/Helm/Terraform/ArgoCD), contributing, and changelog
- Add GitHub Actions workflow (`docs.yml`) to auto-deploy to GitHub Pages on push to main
- Add `docs` dependency group (`mkdocs>=1.6,<2.0`, `mkdocs-material>=9.5`) and update Documentation URL in `pyproject.toml`
- Add docs badge and documentation link to README
- Add documentation site entry to CHANGELOG

Closes #72

## Test plan

- [x] `uv run mkdocs build --strict` passes with no errors
- [x] All 11 pages render correctly with navigation, tabs, and code blocks
- [x] Dark/light mode toggle works
- [x] Cross-page links resolve correctly
- [x] Docs audited against source code — metric labels, method signatures, and config defaults verified