### PR TITLE
allow workflow_dispatch in release workflow condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event_name == 'push'
+      || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'workflow_run'
           && github.event.workflow_run.conclusion == 'success')
     outputs:


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` to the `resolve-tag` job condition so manual dispatch is not skipped

Needed to manually trigger the release workflow for v0.3.0 PyPI publish.