### PR TITLE
fall back to nearest tag when HEAD has no tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,15 +26,18 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
+          # workflow_run: check out the exact commit from the triggering run
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
           fetch-depth: 0
 
       - name: Determine tag
         id: tag
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            # push: tag ref is available directly
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           else
-            # workflow_run: tag points at HEAD (just created by auto-tag)
+            # workflow_run: tag points at HEAD (the auto-tag commit)
             # workflow_dispatch: HEAD may be ahead, fall back to nearest tag
             TAG=$(git tag --points-at HEAD 'v*' | head -1)
             if [[ -z "${TAG}" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,14 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           else
+            # workflow_run: tag points at HEAD (just created by auto-tag)
+            # workflow_dispatch: HEAD may be ahead, fall back to nearest tag
             TAG=$(git tag --points-at HEAD 'v*' | head -1)
             if [[ -z "${TAG}" ]]; then
-              echo "::error::No version tag found pointing at HEAD"
+              TAG=$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "")
+            fi
+            if [[ -z "${TAG}" ]]; then
+              echo "::error::No version tag found"
               exit 1
             fi
             echo "tag=${TAG}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

- When `workflow_dispatch` runs from main, HEAD may be ahead of the release tag
- Try `git tag --points-at HEAD` first (exact match for `workflow_run`)
- Fall back to `git describe --tags --match 'v*' --abbrev=0` (nearest reachable tag for `workflow_dispatch`)

Fixes manual dispatch failing with "No version tag found pointing at HEAD".