### PR TITLE
add workflow pause mechanism for human-in-the-loop (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Workflow pause mechanism — foundation for human-in-the-loop (#40)
+  - `PauseRequestedError` exception for step executors to signal a pause
+  - `StepStatus.PAUSED` and `WorkflowStatus.PAUSED` status values
+  - Engine catches pause requests, saves checkpoint with `status=paused` and `paused_step_id`, and returns cleanly
+  - Resume from paused checkpoint skips completed steps and re-runs the paused step
+  - CLI treats paused workflows as non-error (exit code 0)
+  - Functional validation script (`scripts/validate_pause_resume.py`) and K8s smoke job
 - Pluggable checkpoint backends with `BaseCheckpointer` protocol and `FileCheckpointer` default (JSON-to-disk) (#78)
   - `CheckpointData` Pydantic model with full workflow state serialization
   - Engine integration: auto-generates `run_id`, saves checkpoint on completion/failure, graceful handling of I/O errors

--- a/deploy/k8s/examples/pause-resume-job.yaml
+++ b/deploy/k8s/examples/pause-resume-job.yaml
@@ -7,7 +7,6 @@ data:
   validate_pause_resume.py: |
     """Functional validation of pause/resume in Kubernetes."""
 
-    import asyncio
     import json
     import sys
     import tempfile
@@ -101,7 +100,8 @@ data:
 
         print("\nAll K8s pause/resume validations passed!")
 
-    asyncio.run(main())
+    import anyio
+    anyio.run(main)
 ---
 apiVersion: batch/v1
 kind: Job

--- a/deploy/k8s/examples/pause-resume-job.yaml
+++ b/deploy/k8s/examples/pause-resume-job.yaml
@@ -1,0 +1,149 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pause-resume-script
+  namespace: agentloom
+data:
+  validate_pause_resume.py: |
+    """Functional validation of pause/resume in Kubernetes."""
+
+    import asyncio
+    import json
+    import sys
+    import tempfile
+    from pathlib import Path
+
+    from agentloom.checkpointing.file import FileCheckpointer
+    from agentloom.core.engine import WorkflowEngine
+    from agentloom.core.models import (
+        StepDefinition,
+        StepType,
+        WorkflowConfig,
+        WorkflowDefinition,
+    )
+    from agentloom.core.results import StepStatus, WorkflowStatus
+    from agentloom.exceptions import PauseRequestedError
+    from agentloom.providers.base import BaseProvider, ProviderResponse
+    from agentloom.providers.gateway import ProviderGateway
+    from agentloom.steps.base import BaseStep, StepContext
+    from agentloom.core.results import StepResult
+    from agentloom.steps.registry import create_default_registry
+
+    class FakeProvider(BaseProvider):
+        name = "fake"
+        async def complete(self, messages, model, **kwargs):
+            return ProviderResponse(content="fake-output", model=model, provider="fake")
+        async def stream(self, *a, **kw):
+            raise NotImplementedError
+        def supports_model(self, model):
+            return True
+
+    class PausingStep(BaseStep):
+        async def execute(self, context):
+            if context.step_definition.id == "step_b":
+                raise PauseRequestedError("step_b")
+            from agentloom.steps.llm_call import LLMCallStep
+            return await LLMCallStep().execute(context)
+
+    def _gw():
+        gw = ProviderGateway()
+        gw.register(FakeProvider(), priority=0)
+        return gw
+
+    def _reg():
+        reg = create_default_registry()
+        reg.register(StepType.LLM_CALL, PausingStep)
+        return reg
+
+    def _wf():
+        return WorkflowDefinition(
+            name="pause-k8s",
+            config=WorkflowConfig(provider="fake", model="fake"),
+            state={"input": "hello"},
+            steps=[
+                StepDefinition(id="step_a", type=StepType.LLM_CALL,
+                               prompt="A: {state.input}", output="result_a"),
+                StepDefinition(id="step_b", type=StepType.LLM_CALL,
+                               depends_on=["step_a"],
+                               prompt="B: {state.result_a}", output="result_b"),
+                StepDefinition(id="step_c", type=StepType.LLM_CALL,
+                               depends_on=["step_b"],
+                               prompt="C: {state.result_b}", output="result_c"),
+            ],
+        )
+
+    async def main():
+        with tempfile.TemporaryDirectory() as cp_dir:
+            ckpt = FileCheckpointer(checkpoint_dir=Path(cp_dir))
+
+            print("[1/3] Running workflow (should pause)...")
+            eng = WorkflowEngine(workflow=_wf(), provider_gateway=_gw(),
+                                 step_registry=_reg(), checkpointer=ckpt,
+                                 run_id="k8s-pause")
+            r = await eng.run()
+            assert r.status == WorkflowStatus.PAUSED, f"Expected PAUSED, got {r.status}"
+            print("  OK: paused")
+
+            print("[2/3] Verifying checkpoint...")
+            loaded = await ckpt.load("k8s-pause")
+            assert loaded.status == "paused"
+            assert loaded.paused_step_id == "step_b"
+            assert "step_a" in loaded.completed_steps
+            print("  OK: checkpoint valid")
+
+            print("[3/3] Resuming...")
+            data = await ckpt.load("k8s-pause")
+            resumed = await WorkflowEngine.from_checkpoint(
+                checkpoint_data=data, checkpointer=ckpt, provider_gateway=_gw())
+            r2 = await resumed.run()
+            assert r2.status == WorkflowStatus.SUCCESS, f"Expected SUCCESS, got {r2.status}"
+            print("  OK: resumed successfully")
+
+        print("\nAll K8s pause/resume validations passed!")
+
+    asyncio.run(main())
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: pause-resume-smoke
+  namespace: agentloom
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  activeDeadlineSeconds: 120
+  template:
+    spec:
+      serviceAccountName: agentloom
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: runner
+          image: agentloom:dev
+          imagePullPolicy: Never
+          command: ["/build/.venv/bin/python"]
+          args: ["/scripts/validate_pause_resume.py"]
+          env:
+            - name: UV_CACHE_DIR
+              value: /tmp/.uv-cache
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 50m
+            limits:
+              memory: 128Mi
+          securityContext:
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: script
+          configMap:
+            name: pause-resume-script

--- a/scripts/validate_pause_resume.py
+++ b/scripts/validate_pause_resume.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Functional validation of the pause/resume mechanism.
+
+Exercises the full flow programmatically:
+  1. Run a 3-step workflow that pauses at step_b
+  2. Verify checkpoint saved with status=paused
+  3. Resume from the checkpoint
+  4. Verify workflow completes successfully
+
+Can be run standalone:
+    uv run python scripts/validate_pause_resume.py
+Or inside Docker:
+    docker run --rm agentloom:dev python scripts/validate_pause_resume.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+from agentloom.checkpointing.file import FileCheckpointer
+from agentloom.core.engine import WorkflowEngine
+from agentloom.core.models import (
+    StepDefinition,
+    StepType,
+    WorkflowConfig,
+    WorkflowDefinition,
+)
+from agentloom.core.results import StepResult, StepStatus, WorkflowStatus
+from agentloom.exceptions import PauseRequestedError
+from agentloom.providers.base import BaseProvider, ProviderResponse
+from agentloom.providers.gateway import ProviderGateway
+from agentloom.steps.base import BaseStep, StepContext
+from agentloom.steps.registry import StepRegistry, create_default_registry
+
+
+# --- Helpers ----------------------------------------------------------------
+
+
+class FakeProvider(BaseProvider):
+    """Minimal provider that returns a fixed response."""
+
+    name = "fake"
+
+    async def complete(self, messages, model, **kwargs):  # noqa: ANN001,ANN003
+        return ProviderResponse(
+            content="fake-output", model=model, provider="fake"
+        )
+
+    async def stream(self, *a, **kw):  # noqa: ANN002,ANN003
+        raise NotImplementedError
+
+    def supports_model(self, model: str) -> bool:
+        return True
+
+
+class PausingStep(BaseStep):
+    """LLM step that pauses on step_b, delegates otherwise."""
+
+    async def execute(self, context: StepContext) -> StepResult:
+        if context.step_definition.id == "step_b":
+            raise PauseRequestedError("step_b")
+        from agentloom.steps.llm_call import LLMCallStep
+
+        return await LLMCallStep().execute(context)
+
+
+def _gateway() -> ProviderGateway:
+    gw = ProviderGateway()
+    gw.register(FakeProvider(), priority=0)
+    return gw
+
+
+def _registry_pausing() -> StepRegistry:
+    reg = create_default_registry()
+    reg.register(StepType.LLM_CALL, PausingStep)
+    return reg
+
+
+def _workflow() -> WorkflowDefinition:
+    return WorkflowDefinition(
+        name="pause-validate",
+        config=WorkflowConfig(provider="fake", model="fake"),
+        state={"input": "hello"},
+        steps=[
+            StepDefinition(
+                id="step_a",
+                type=StepType.LLM_CALL,
+                prompt="A: {state.input}",
+                output="result_a",
+            ),
+            StepDefinition(
+                id="step_b",
+                type=StepType.LLM_CALL,
+                depends_on=["step_a"],
+                prompt="B: {state.result_a}",
+                output="result_b",
+            ),
+            StepDefinition(
+                id="step_c",
+                type=StepType.LLM_CALL,
+                depends_on=["step_b"],
+                prompt="C: {state.result_b}",
+                output="result_c",
+            ),
+        ],
+    )
+
+
+# --- Validation -------------------------------------------------------------
+
+
+def _ok(msg: str) -> None:
+    print(f"  ✓ {msg}")
+
+
+def _fail(msg: str) -> None:
+    print(f"  ✗ {msg}")
+    sys.exit(1)
+
+
+async def main() -> None:
+    with tempfile.TemporaryDirectory() as cp_dir:
+        checkpointer = FileCheckpointer(checkpoint_dir=Path(cp_dir))
+
+        # ── Step 1: Run → should pause ──────────────────────────────
+        print("\n[1/4] Running workflow (should pause at step_b)...")
+        engine = WorkflowEngine(
+            workflow=_workflow(),
+            provider_gateway=_gateway(),
+            step_registry=_registry_pausing(),
+            checkpointer=checkpointer,
+            run_id="validate-pause",
+        )
+        result = await engine.run()
+
+        if result.status == WorkflowStatus.PAUSED:
+            _ok(f"Workflow paused (status={result.status.value})")
+        else:
+            _fail(f"Expected PAUSED, got {result.status.value}")
+
+        if result.step_results["step_a"].status == StepStatus.SUCCESS:
+            _ok("step_a completed before pause")
+        else:
+            _fail("step_a should be SUCCESS")
+
+        if result.step_results["step_b"].status == StepStatus.PAUSED:
+            _ok("step_b has PAUSED status")
+        else:
+            _fail(f"step_b should be PAUSED, got {result.step_results['step_b'].status}")
+
+        # ── Step 2: Verify checkpoint on disk ───────────────────────
+        print("\n[2/4] Verifying checkpoint file...")
+        cp_files = list(Path(cp_dir).glob("*.json"))
+        if len(cp_files) == 1:
+            _ok(f"Checkpoint file: {cp_files[0].name}")
+        else:
+            _fail(f"Expected 1 checkpoint file, found {len(cp_files)}")
+
+        checkpoint = json.loads(cp_files[0].read_text())
+        if checkpoint["status"] == "paused":
+            _ok("Checkpoint status = paused")
+        else:
+            _fail(f"Checkpoint status = {checkpoint['status']}")
+
+        if checkpoint["paused_step_id"] == "step_b":
+            _ok("paused_step_id = step_b")
+        else:
+            _fail(f"paused_step_id = {checkpoint['paused_step_id']}")
+
+        if "step_a" in checkpoint["completed_steps"]:
+            _ok("step_a in completed_steps")
+        else:
+            _fail("step_a not in completed_steps")
+
+        if "step_b" not in checkpoint["completed_steps"]:
+            _ok("step_b NOT in completed_steps (correct)")
+        else:
+            _fail("step_b should not be in completed_steps")
+
+        # ── Step 3: List runs ───────────────────────────────────────
+        print("\n[3/4] Listing checkpoint runs...")
+        runs = await checkpointer.list_runs()
+        if len(runs) == 1 and runs[0].run_id == "validate-pause":
+            _ok(f"Found 1 run: {runs[0].run_id} (status={runs[0].status})")
+        else:
+            _fail(f"Expected 1 run, found {len(runs)}")
+
+        # ── Step 4: Resume → should complete ────────────────────────
+        print("\n[4/4] Resuming workflow...")
+        checkpoint_data = await checkpointer.load("validate-pause")
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=checkpoint_data,
+            checkpointer=checkpointer,
+            provider_gateway=_gateway(),
+            # Default registry — no pausing, step_b will run normally
+        )
+        resume_result = await resumed.run()
+
+        if resume_result.status == WorkflowStatus.SUCCESS:
+            _ok(f"Resumed workflow completed (status={resume_result.status.value})")
+        else:
+            _fail(f"Expected SUCCESS, got {resume_result.status.value}")
+
+        if resume_result.step_results["step_b"].status == StepStatus.SUCCESS:
+            _ok("step_b now SUCCESS after resume")
+        else:
+            _fail(f"step_b status = {resume_result.step_results['step_b'].status}")
+
+        if resume_result.step_results["step_c"].status == StepStatus.SUCCESS:
+            _ok("step_c completed after resume")
+        else:
+            _fail(f"step_c status = {resume_result.step_results['step_c'].status}")
+
+        # Verify final checkpoint updated
+        final = await checkpointer.load("validate-pause")
+        if final.status == "success":
+            _ok("Final checkpoint status = success")
+        else:
+            _fail(f"Final checkpoint status = {final.status}")
+
+        print("\n══════════════════════════════════════════════════")
+        print("  All pause/resume validations passed!")
+        print("══════════════════════════════════════════════════\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/validate_pause_resume.py
+++ b/scripts/validate_pause_resume.py
@@ -15,7 +15,6 @@ Or inside Docker:
 
 from __future__ import annotations
 
-import asyncio
 import json
 import sys
 import tempfile
@@ -36,7 +35,6 @@ from agentloom.providers.gateway import ProviderGateway
 from agentloom.steps.base import BaseStep, StepContext
 from agentloom.steps.registry import StepRegistry, create_default_registry
 
-
 # --- Helpers ----------------------------------------------------------------
 
 
@@ -46,9 +44,7 @@ class FakeProvider(BaseProvider):
     name = "fake"
 
     async def complete(self, messages, model, **kwargs):  # noqa: ANN001,ANN003
-        return ProviderResponse(
-            content="fake-output", model=model, provider="fake"
-        )
+        return ProviderResponse(content="fake-output", model=model, provider="fake")
 
     async def stream(self, *a, **kw):  # noqa: ANN002,ANN003
         raise NotImplementedError
@@ -228,4 +224,6 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    import anyio
+
+    anyio.run(main)

--- a/src/agentloom/cli/resume.py
+++ b/src/agentloom/cli/resume.py
@@ -121,5 +121,5 @@ async def _resume_async(
         observer.shutdown()
     await gateway.close()
 
-    if result.status != WorkflowStatus.SUCCESS:
+    if result.status not in (WorkflowStatus.SUCCESS, WorkflowStatus.PAUSED):
         raise typer.Exit(1)

--- a/src/agentloom/cli/run.py
+++ b/src/agentloom/cli/run.py
@@ -165,7 +165,7 @@ async def _run_async(
         observer.shutdown()
     await gateway.close()
 
-    if result.status != WorkflowStatus.SUCCESS:
+    if result.status not in (WorkflowStatus.SUCCESS, WorkflowStatus.PAUSED):
         raise typer.Exit(1)
 
 
@@ -251,6 +251,7 @@ def _print_result(result: object) -> None:
         "failed": "[FAIL]",
         "timeout": "[TIMEOUT]",
         "budget_exceeded": "[BUDGET]",
+        "paused": "[PAUSED]",
     }
 
     typer.echo(f"\n{'=' * 60}")
@@ -265,11 +266,12 @@ def _print_result(result: object) -> None:
 
     typer.echo("\nSteps:")
     for step_id, sr in r.step_results.items():
-        icon = (
-            "[OK]"
-            if sr.status == StepStatus.SUCCESS
-            else ("[SKIP]" if sr.status == StepStatus.SKIPPED else "[FAIL]")
-        )
+        step_icons = {
+            StepStatus.SUCCESS: "[OK]",
+            StepStatus.SKIPPED: "[SKIP]",
+            StepStatus.PAUSED: "[PAUSED]",
+        }
+        icon = step_icons.get(sr.status, "[FAIL]")
         line = f"  {icon} {step_id} ({sr.duration_ms:.0f}ms)"
         if sr.cost_usd > 0:
             line += f" ${sr.cost_usd:.4f}"

--- a/src/agentloom/core/engine.py
+++ b/src/agentloom/core/engine.py
@@ -564,10 +564,20 @@ class WorkflowEngine:
                 raise
 
             except PauseRequestedError:
-                await self.state.set_step_result(
-                    step_id,
-                    StepResult(step_id=step_id, status=StepStatus.PAUSED),
+                paused_result = StepResult(
+                    step_id=step_id, status=StepStatus.PAUSED
                 )
+                await self.state.set_step_result(step_id, paused_result)
+                if self.observer:
+                    self.observer.on_step_end(
+                        step_id,
+                        step_def.type.value,
+                        "paused",
+                        paused_result.duration_ms,
+                        paused_result.cost_usd,
+                        paused_result.token_usage.total_tokens,
+                        stream=should_stream,
+                    )
                 raise
 
             except Exception as e:

--- a/src/agentloom/core/engine.py
+++ b/src/agentloom/core/engine.py
@@ -23,6 +23,7 @@ from agentloom.core.results import (
 from agentloom.core.state import StateManager
 from agentloom.exceptions import (
     BudgetExceededError,
+    PauseRequestedError,
     WorkflowError,
     WorkflowTimeoutError,
 )
@@ -30,6 +31,23 @@ from agentloom.steps.base import BaseStep, StepContext
 from agentloom.steps.registry import StepRegistry, create_default_registry
 
 logger = logging.getLogger("agentloom.engine")
+
+
+def _extract_pause_error(exc: BaseException) -> PauseRequestedError | None:
+    """Unwrap a ``PauseRequestedError`` from an ``ExceptionGroup``.
+
+    anyio task groups always wrap step exceptions in an ``ExceptionGroup``,
+    so we need to inspect the group to find pause requests.  Returns
+    ``None`` if *exc* does not contain a ``PauseRequestedError``.
+    """
+    if isinstance(exc, PauseRequestedError):
+        return exc
+    if isinstance(exc, ExceptionGroup):
+        for inner in exc.exceptions:
+            found = _extract_pause_error(inner)
+            if found is not None:
+                return found
+    return None
 
 
 class WorkflowEngine:
@@ -349,6 +367,38 @@ class WorkflowEngine:
 
         except Exception as e:
             duration = (time.monotonic() - start) * 1000
+
+            # Check for PauseRequestedError wrapped in ExceptionGroup
+            # (anyio task groups always wrap step exceptions).
+            pause_err = _extract_pause_error(e)
+            if pause_err is not None:
+                await self._save_checkpoint("paused", paused_step_id=pause_err.step_id)
+                step_results = await self.state.all_step_results()
+                final_state = await self.state.get_state_snapshot()
+                if self.observer:
+                    self.observer.on_workflow_end(
+                        workflow_name,
+                        "paused",
+                        duration,
+                        sum(r.token_usage.total_tokens for r in step_results.values()),
+                        sum(r.cost_usd for r in step_results.values()),
+                    )
+                logger.info(
+                    "Workflow '%s' paused at step '%s'",
+                    workflow_name,
+                    pause_err.step_id,
+                )
+                return WorkflowResult(
+                    workflow_name=workflow_name,
+                    status=WorkflowStatus.PAUSED,
+                    step_results=step_results,
+                    final_state=final_state,
+                    total_duration_ms=duration,
+                    total_tokens=sum(r.token_usage.total_tokens for r in step_results.values()),
+                    total_cost_usd=sum(r.cost_usd for r in step_results.values()),
+                    error=str(pause_err),
+                )
+
             await self._save_checkpoint("failed")
             if self.observer:
                 self.observer.on_workflow_end(
@@ -511,6 +561,13 @@ class WorkflowEngine:
                 break
 
             except BudgetExceededError:
+                raise
+
+            except PauseRequestedError:
+                await self.state.set_step_result(
+                    step_id,
+                    StepResult(step_id=step_id, status=StepStatus.PAUSED),
+                )
                 raise
 
             except Exception as e:

--- a/src/agentloom/core/engine.py
+++ b/src/agentloom/core/engine.py
@@ -564,9 +564,7 @@ class WorkflowEngine:
                 raise
 
             except PauseRequestedError:
-                paused_result = StepResult(
-                    step_id=step_id, status=StepStatus.PAUSED
-                )
+                paused_result = StepResult(step_id=step_id, status=StepStatus.PAUSED)
                 await self.state.set_step_result(step_id, paused_result)
                 if self.observer:
                     self.observer.on_step_end(

--- a/src/agentloom/core/results.py
+++ b/src/agentloom/core/results.py
@@ -17,6 +17,7 @@ class StepStatus(StrEnum):
     FAILED = "failed"
     SKIPPED = "skipped"
     TIMEOUT = "timeout"
+    PAUSED = "paused"
 
 
 class TokenUsage(BaseModel):
@@ -50,6 +51,7 @@ class WorkflowStatus(StrEnum):
     FAILED = "failed"
     TIMEOUT = "timeout"
     BUDGET_EXCEEDED = "budget_exceeded"
+    PAUSED = "paused"
 
 
 class WorkflowResult(BaseModel):

--- a/src/agentloom/exceptions.py
+++ b/src/agentloom/exceptions.py
@@ -70,3 +70,16 @@ class StepTimeoutError(StepError):
 
     def __init__(self, step_id: str, timeout: float) -> None:
         super().__init__(step_id, f"Timed out after {timeout}s")
+
+
+class PauseRequestedError(AgentLoomError):
+    """A step has requested the workflow to pause.
+
+    Raised by step executors (e.g. an approval gate) to signal that the
+    engine should save a checkpoint and stop execution until a human
+    resumes the workflow.
+    """
+
+    def __init__(self, step_id: str, message: str = "") -> None:
+        self.step_id = step_id
+        super().__init__(message or f"Pause requested at step '{step_id}'")

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -227,3 +227,19 @@ class TestPrintResult:
             final_state={},
         )
         _print_result(result)
+
+    def test_prints_paused(self) -> None:
+        from agentloom.cli.run import _print_result
+        from agentloom.core.results import StepResult, StepStatus, WorkflowResult, WorkflowStatus
+
+        result = WorkflowResult(
+            workflow_name="test",
+            status=WorkflowStatus.PAUSED,
+            error="Pause requested at step 'review'",
+            step_results={
+                "draft": StepResult(step_id="draft", status=StepStatus.SUCCESS, duration_ms=100.0),
+                "review": StepResult(step_id="review", status=StepStatus.PAUSED),
+            },
+            final_state={"draft_output": "hello"},
+        )
+        _print_result(result)

--- a/tests/core/test_engine_pause.py
+++ b/tests/core/test_engine_pause.py
@@ -21,11 +21,6 @@ from agentloom.steps.base import BaseStep, StepContext
 from agentloom.steps.registry import StepRegistry, create_default_registry
 from tests.conftest import MockProvider
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
 def _mock_gateway(provider: MockProvider | None = None) -> ProviderGateway:
     gw = ProviderGateway()
     gw.register(provider or MockProvider(), priority=0)
@@ -99,11 +94,6 @@ def _registry_that_pauses_on(step_id: str) -> StepRegistry:
     return reg
 
 
-# ---------------------------------------------------------------------------
-# Test _extract_pause_error helper
-# ---------------------------------------------------------------------------
-
-
 class TestExtractPauseError:
     def test_bare_pause_error(self) -> None:
         err = PauseRequestedError("s1")
@@ -126,11 +116,6 @@ class TestExtractPauseError:
 
     def test_unrelated_exception(self) -> None:
         assert _extract_pause_error(RuntimeError("x")) is None
-
-
-# ---------------------------------------------------------------------------
-# Engine pause tests
-# ---------------------------------------------------------------------------
 
 
 class TestEnginePause:
@@ -207,10 +192,23 @@ class TestEnginePause:
         assert "result_a" in result.final_state
         assert "result_b" not in result.final_state
 
+    async def test_pause_notifies_observer(self) -> None:
+        """Observer.on_workflow_end is called with 'paused' status."""
+        from unittest.mock import MagicMock
 
-# ---------------------------------------------------------------------------
-# Resume from paused checkpoint
-# ---------------------------------------------------------------------------
+        observer = MagicMock()
+        engine = WorkflowEngine(
+            workflow=_three_step_workflow(),
+            provider_gateway=_mock_gateway(),
+            step_registry=_registry_that_pauses_on("step_b"),
+            observer=observer,
+        )
+        result = await engine.run()
+
+        assert result.status == WorkflowStatus.PAUSED
+        observer.on_workflow_end.assert_called_once()
+        call_args = observer.on_workflow_end.call_args
+        assert call_args[0][1] == "paused"
 
 
 class TestResumeFromPaused:
@@ -352,11 +350,6 @@ class TestResumeFromPaused:
         assert len(provider.calls) == 2
         assert result.step_results["step_b"].status == StepStatus.SUCCESS
         assert result.step_results["step_c"].status == StepStatus.SUCCESS
-
-
-# ---------------------------------------------------------------------------
-# Pause with router
-# ---------------------------------------------------------------------------
 
 
 class TestPauseWithRouter:

--- a/tests/core/test_engine_pause.py
+++ b/tests/core/test_engine_pause.py
@@ -21,6 +21,7 @@ from agentloom.steps.base import BaseStep, StepContext
 from agentloom.steps.registry import StepRegistry, create_default_registry
 from tests.conftest import MockProvider
 
+
 def _mock_gateway(provider: MockProvider | None = None) -> ProviderGateway:
     gw = ProviderGateway()
     gw.register(provider or MockProvider(), priority=0)

--- a/tests/core/test_engine_pause.py
+++ b/tests/core/test_engine_pause.py
@@ -1,0 +1,458 @@
+"""Tests for the workflow pause mechanism (Issue #40)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentloom.checkpointing.base import CheckpointData
+from agentloom.checkpointing.file import FileCheckpointer
+from agentloom.core.engine import WorkflowEngine, _extract_pause_error
+from agentloom.core.models import (
+    Condition,
+    StepDefinition,
+    StepType,
+    WorkflowConfig,
+    WorkflowDefinition,
+)
+from agentloom.core.results import StepResult, StepStatus, WorkflowStatus
+from agentloom.exceptions import PauseRequestedError
+from agentloom.providers.gateway import ProviderGateway
+from agentloom.steps.base import BaseStep, StepContext
+from agentloom.steps.registry import StepRegistry, create_default_registry
+from tests.conftest import MockProvider
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_gateway(provider: MockProvider | None = None) -> ProviderGateway:
+    gw = ProviderGateway()
+    gw.register(provider or MockProvider(), priority=0)
+    return gw
+
+
+def _three_step_workflow() -> WorkflowDefinition:
+    """Linear workflow: step_a → step_b → step_c."""
+    return WorkflowDefinition(
+        name="pause-test",
+        config=WorkflowConfig(provider="mock", model="mock-model"),
+        state={"input": "hello"},
+        steps=[
+            StepDefinition(
+                id="step_a",
+                type=StepType.LLM_CALL,
+                prompt="Process: {state.input}",
+                output="result_a",
+            ),
+            StepDefinition(
+                id="step_b",
+                type=StepType.LLM_CALL,
+                depends_on=["step_a"],
+                prompt="Continue: {state.result_a}",
+                output="result_b",
+            ),
+            StepDefinition(
+                id="step_c",
+                type=StepType.LLM_CALL,
+                depends_on=["step_b"],
+                prompt="Finish: {state.result_b}",
+                output="result_c",
+            ),
+        ],
+    )
+
+
+class PausingStep(BaseStep):
+    """Step executor that raises PauseRequestedError."""
+
+    async def execute(self, context: StepContext) -> StepResult:
+        raise PauseRequestedError(context.step_definition.id)
+
+
+class PausingOnSecondCallStep(BaseStep):
+    """LLM-call step that pauses on a specific step_id.
+
+    First call runs the real LLM executor; when the step_id matches
+    ``pause_on``, it raises ``PauseRequestedError`` instead.
+    """
+
+    pause_on: str = ""
+
+    async def execute(self, context: StepContext) -> StepResult:
+        if context.step_definition.id == self.__class__.pause_on:
+            raise PauseRequestedError(context.step_definition.id)
+        # Delegate to the real LLM executor
+        from agentloom.steps.llm_call import LLMCallStep
+
+        return await LLMCallStep().execute(context)
+
+
+def _registry_that_pauses_on(step_id: str) -> StepRegistry:
+    """Build a step registry whose LLM_CALL executor pauses on *step_id*."""
+
+    class _Pauser(PausingOnSecondCallStep):
+        pause_on = step_id
+
+    reg = create_default_registry()
+    reg.register(StepType.LLM_CALL, _Pauser)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# Test _extract_pause_error helper
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPauseError:
+    def test_bare_pause_error(self) -> None:
+        err = PauseRequestedError("s1")
+        assert _extract_pause_error(err) is err
+
+    def test_wrapped_in_exception_group(self) -> None:
+        err = PauseRequestedError("s1")
+        group = ExceptionGroup("tg", [err])
+        assert _extract_pause_error(group) is err
+
+    def test_nested_exception_group(self) -> None:
+        err = PauseRequestedError("s1")
+        inner = ExceptionGroup("inner", [err])
+        outer = ExceptionGroup("outer", [inner])
+        assert _extract_pause_error(outer) is err
+
+    def test_no_pause_error(self) -> None:
+        group = ExceptionGroup("tg", [RuntimeError("boom")])
+        assert _extract_pause_error(group) is None
+
+    def test_unrelated_exception(self) -> None:
+        assert _extract_pause_error(RuntimeError("x")) is None
+
+
+# ---------------------------------------------------------------------------
+# Engine pause tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnginePause:
+    """Test that the engine handles PauseRequestedError correctly."""
+
+    async def test_pause_returns_paused_status(self) -> None:
+        """Engine returns WorkflowStatus.PAUSED when a step raises PauseRequestedError."""
+        engine = WorkflowEngine(
+            workflow=_three_step_workflow(),
+            provider_gateway=_mock_gateway(),
+            step_registry=_registry_that_pauses_on("step_b"),
+        )
+        result = await engine.run()
+
+        assert result.status == WorkflowStatus.PAUSED
+        assert "step_b" in (result.error or "")
+
+    async def test_pause_saves_checkpoint(self, tmp_path: Path) -> None:
+        """Checkpoint is saved with status='paused' and paused_step_id."""
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+
+        engine = WorkflowEngine(
+            workflow=_three_step_workflow(),
+            provider_gateway=_mock_gateway(),
+            step_registry=_registry_that_pauses_on("step_b"),
+            checkpointer=checkpointer,
+        )
+        result = await engine.run()
+
+        assert result.status == WorkflowStatus.PAUSED
+
+        loaded = await checkpointer.load(engine.run_id)
+        assert loaded.status == "paused"
+        assert loaded.paused_step_id == "step_b"
+
+    async def test_pause_preserves_completed_steps(self, tmp_path: Path) -> None:
+        """Steps before the pause point are in completed_steps; paused step is not."""
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+
+        engine = WorkflowEngine(
+            workflow=_three_step_workflow(),
+            provider_gateway=_mock_gateway(),
+            step_registry=_registry_that_pauses_on("step_b"),
+            checkpointer=checkpointer,
+        )
+        await engine.run()
+
+        loaded = await checkpointer.load(engine.run_id)
+        assert "step_a" in loaded.completed_steps
+        assert "step_b" not in loaded.completed_steps
+        assert "step_c" not in loaded.completed_steps
+
+    async def test_pause_step_result_is_paused(self) -> None:
+        """The paused step's result has StepStatus.PAUSED."""
+        engine = WorkflowEngine(
+            workflow=_three_step_workflow(),
+            provider_gateway=_mock_gateway(),
+            step_registry=_registry_that_pauses_on("step_b"),
+        )
+        result = await engine.run()
+
+        assert result.step_results["step_a"].status == StepStatus.SUCCESS
+        assert result.step_results["step_b"].status == StepStatus.PAUSED
+
+    async def test_pause_state_has_completed_outputs(self) -> None:
+        """State includes outputs from steps completed before the pause."""
+        engine = WorkflowEngine(
+            workflow=_three_step_workflow(),
+            provider_gateway=_mock_gateway(),
+            step_registry=_registry_that_pauses_on("step_b"),
+        )
+        result = await engine.run()
+
+        assert "result_a" in result.final_state
+        assert "result_b" not in result.final_state
+
+
+# ---------------------------------------------------------------------------
+# Resume from paused checkpoint
+# ---------------------------------------------------------------------------
+
+
+class TestResumeFromPaused:
+    """Test that resuming from a paused checkpoint works correctly."""
+
+    async def test_resume_completes_workflow(self, tmp_path: Path) -> None:
+        """Resume from a paused checkpoint runs remaining steps to success."""
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+
+        # First run — pauses at step_b
+        engine = WorkflowEngine(
+            workflow=_three_step_workflow(),
+            provider_gateway=_mock_gateway(),
+            step_registry=_registry_that_pauses_on("step_b"),
+            checkpointer=checkpointer,
+            run_id="pause-resume-test",
+        )
+        first_result = await engine.run()
+        assert first_result.status == WorkflowStatus.PAUSED
+
+        # Resume with default registry — step_b and step_c should execute normally
+        resume_provider = MockProvider()
+        resume_gw = ProviderGateway()
+        resume_gw.register(resume_provider, priority=0)
+
+        checkpoint_data = await checkpointer.load("pause-resume-test")
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=checkpoint_data,
+            checkpointer=checkpointer,
+            provider_gateway=resume_gw,
+        )
+        second_result = await resumed.run()
+
+        assert second_result.status == WorkflowStatus.SUCCESS
+        assert "result_b" in second_result.final_state
+        assert "result_c" in second_result.final_state
+
+    async def test_resume_skips_completed_steps(self, tmp_path: Path) -> None:
+        """On resume, only the remaining steps execute."""
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+
+        engine = WorkflowEngine(
+            workflow=_three_step_workflow(),
+            provider_gateway=_mock_gateway(),
+            step_registry=_registry_that_pauses_on("step_b"),
+            checkpointer=checkpointer,
+            run_id="skip-test",
+        )
+        await engine.run()
+
+        # Resume
+        resume_provider = MockProvider()
+        resume_gw = ProviderGateway()
+        resume_gw.register(resume_provider, priority=0)
+
+        checkpoint_data = await checkpointer.load("skip-test")
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=checkpoint_data,
+            checkpointer=checkpointer,
+            provider_gateway=resume_gw,
+        )
+        await resumed.run()
+
+        # step_a was already done — provider called for step_b and step_c
+        assert len(resume_provider.calls) == 2
+
+    async def test_resume_updates_checkpoint_to_success(self, tmp_path: Path) -> None:
+        """After successful resume, checkpoint status changes to 'success'."""
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+
+        engine = WorkflowEngine(
+            workflow=_three_step_workflow(),
+            provider_gateway=_mock_gateway(),
+            step_registry=_registry_that_pauses_on("step_b"),
+            checkpointer=checkpointer,
+            run_id="update-test",
+        )
+        await engine.run()
+
+        # Resume
+        checkpoint_data = await checkpointer.load("update-test")
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=checkpoint_data,
+            checkpointer=checkpointer,
+            provider_gateway=_mock_gateway(),
+        )
+        await resumed.run()
+
+        final = await checkpointer.load("update-test")
+        assert final.status == "success"
+        assert final.paused_step_id is None
+
+    async def test_resume_from_manual_checkpoint(self, tmp_path: Path) -> None:
+        """Resume from a manually-constructed paused checkpoint."""
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+        workflow = _three_step_workflow()
+
+        checkpoint_data = CheckpointData(
+            workflow_name="pause-test",
+            run_id="manual-pause",
+            workflow_definition=workflow.model_dump(),
+            state={
+                "input": "hello",
+                "result_a": "Mock response",
+                "steps": {
+                    "step_a": {"output": "Mock response", "status": "success"},
+                    "step_b": {"output": None, "status": "paused"},
+                },
+            },
+            step_results={
+                "step_a": {
+                    "step_id": "step_a",
+                    "status": "success",
+                    "output": "Mock response",
+                    "duration_ms": 10.0,
+                },
+            },
+            completed_steps=["step_a"],
+            status="paused",
+            paused_step_id="step_b",
+            created_at="2026-04-12T10:00:00+00:00",
+            updated_at="2026-04-12T10:00:01+00:00",
+        )
+        await checkpointer.save(checkpoint_data)
+
+        provider = MockProvider()
+        gw = ProviderGateway()
+        gw.register(provider, priority=0)
+
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=checkpoint_data,
+            checkpointer=checkpointer,
+            provider_gateway=gw,
+        )
+        result = await resumed.run()
+
+        assert result.status == WorkflowStatus.SUCCESS
+        # step_b and step_c should run
+        assert len(provider.calls) == 2
+        assert result.step_results["step_b"].status == StepStatus.SUCCESS
+        assert result.step_results["step_c"].status == StepStatus.SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# Pause with router
+# ---------------------------------------------------------------------------
+
+
+class TestPauseWithRouter:
+    """Test pause/resume with router branching."""
+
+    async def test_pause_after_router_resumes_correctly(self, tmp_path: Path) -> None:
+        """Pause after a router; resume respects the router's branch selection."""
+        workflow = WorkflowDefinition(
+            name="router-pause",
+            config=WorkflowConfig(provider="mock", model="mock-model"),
+            state={"input": "test", "classification": "billing"},
+            steps=[
+                StepDefinition(
+                    id="classify",
+                    type=StepType.LLM_CALL,
+                    prompt="Classify: {state.input}",
+                    output="classification",
+                ),
+                StepDefinition(
+                    id="route",
+                    type=StepType.ROUTER,
+                    depends_on=["classify"],
+                    conditions=[
+                        Condition(
+                            expression="state.classification == 'billing'",
+                            target="billing",
+                        ),
+                    ],
+                    default="general",
+                ),
+                StepDefinition(
+                    id="billing",
+                    type=StepType.LLM_CALL,
+                    depends_on=["route"],
+                    prompt="Handle billing: {state.input}",
+                    output="response",
+                ),
+                StepDefinition(
+                    id="general",
+                    type=StepType.LLM_CALL,
+                    depends_on=["route"],
+                    prompt="Handle general: {state.input}",
+                    output="response",
+                ),
+            ],
+        )
+
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+
+        # Build a checkpoint where classify + route are done, paused before billing.
+        checkpoint_data = CheckpointData(
+            workflow_name="router-pause",
+            run_id="router-pause-run",
+            workflow_definition=workflow.model_dump(),
+            state={
+                "input": "test",
+                "classification": "billing",
+                "steps": {
+                    "classify": {"output": "billing", "status": "success"},
+                    "route": {"output": "billing", "status": "success"},
+                },
+            },
+            step_results={
+                "classify": {
+                    "step_id": "classify",
+                    "status": "success",
+                    "output": "billing",
+                    "duration_ms": 5.0,
+                },
+                "route": {
+                    "step_id": "route",
+                    "status": "success",
+                    "output": "billing",
+                    "duration_ms": 1.0,
+                },
+            },
+            completed_steps=["classify", "route"],
+            status="paused",
+            paused_step_id="billing",
+            created_at="2026-04-12T10:00:00+00:00",
+            updated_at="2026-04-12T10:00:01+00:00",
+        )
+        await checkpointer.save(checkpoint_data)
+
+        provider = MockProvider()
+        gw = ProviderGateway()
+        gw.register(provider, priority=0)
+
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=checkpoint_data,
+            checkpointer=checkpointer,
+            provider_gateway=gw,
+        )
+        result = await resumed.run()
+
+        assert result.status == WorkflowStatus.SUCCESS
+        assert result.step_results["billing"].status == StepStatus.SUCCESS
+        assert result.step_results["general"].status == StepStatus.SKIPPED
+        assert len(provider.calls) == 1


### PR DESCRIPTION
## What

Adds the internal pause/resume mechanism to the workflow engine. A step executor can raise `PauseRequestedError` to halt execution — the engine saves a checkpoint with `status=paused` and `paused_step_id`, and a subsequent `agentloom resume` continues from that point.

New additions:
- `PauseRequestedError` exception in `exceptions.py`
- `StepStatus.PAUSED` and `WorkflowStatus.PAUSED`
- Engine unwraps `PauseRequestedError` from anyio `ExceptionGroup`, saves paused checkpoint, returns `WorkflowResult(PAUSED)`
- CLI treats paused as non-error (exit code 0) with `[PAUSED]` display
- 15 unit tests covering pause, resume, checkpoint state, and router interactions
- Functional validation script (`scripts/validate_pause_resume.py`) and K8s smoke job

## Why

Foundation for the human-in-the-loop milestone. Issues #41 (approval gate step type) and #42 (webhook notifications) build on this mechanism. Without it, there is no way for a workflow to pause cleanly and resume later.

Closes #40

## Testing

- [x] \`uv run pytest\` passes (744 tests)
- [x] \`uv run ruff check src/ tests/\` clean
- [x] \`uv run mypy src/\` clean
- [x] \`uv run python scripts/validate_pause_resume.py\` — functional validation (local)
- [x] Docker: \`docker run --rm -v \$(pwd)/scripts:/build/scripts:ro agentloom:dev python scripts/validate_pause_resume.py\`
- [x] Kubernetes: \`kubectl apply -f deploy/k8s/examples/pause-resume-job.yaml\` — Kind smoke test passed

## Notes

- There is no YAML step type that triggers pause yet — that is #41 (`type: approval`). This PR only adds the engine-level mechanism.
- `_extract_pause_error()` recursively unwraps `ExceptionGroup` to find `PauseRequestedError`, since anyio task groups always wrap step exceptions.
- The existing `except BudgetExceededError` / `except WorkflowTimeoutError` handlers remain as-is (`pragma: no cover`) — they share the same ExceptionGroup limitation.