### PR TITLE
add approval gate step type for human-in-the-loop (#41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Approval gate step type — human-in-the-loop decision point (#41)
+  - `StepType.APPROVAL_GATE` pauses the workflow and waits for human approval or rejection
+  - Decision injected via `_approval.<step_id>` state key on resume
+  - `--approve` / `--reject` mutually exclusive flags on `agentloom resume`
+  - `timeout_seconds` and `on_timeout` fields for automatic resolution
+  - Example workflow (29), validation script, and K8s smoke job
 - Workflow pause mechanism — foundation for human-in-the-loop (#40)
   - `PauseRequestedError` exception for step executors to signal a pause
   - `StepStatus.PAUSED` and `WorkflowStatus.PAUSED` status values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `StepType.APPROVAL_GATE` pauses the workflow and waits for human approval or rejection
   - Decision injected via `_approval.<step_id>` state key on resume
   - `--approve` / `--reject` mutually exclusive flags on `agentloom resume`
-  - `timeout_seconds` and `on_timeout` fields for automatic resolution
+  - `timeout_seconds` and `on_timeout` schema fields (consumed by webhook callback server in #42)
   - Example workflow (29), validation script, and K8s smoke job
 - Workflow pause mechanism — foundation for human-in-the-loop (#40)
   - `PauseRequestedError` exception for step executors to signal a pause

--- a/deploy/k8s/examples/approval-gate-job.yaml
+++ b/deploy/k8s/examples/approval-gate-job.yaml
@@ -1,0 +1,132 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: approval-gate-script
+  namespace: agentloom
+data:
+  validate_approval_gate.py: |
+    """Functional validation of approval gate in Kubernetes."""
+
+    import sys
+    import tempfile
+    from pathlib import Path
+
+    from agentloom.checkpointing.file import FileCheckpointer
+    from agentloom.core.engine import WorkflowEngine
+    from agentloom.core.models import (
+        StepDefinition,
+        StepType,
+        WorkflowConfig,
+        WorkflowDefinition,
+    )
+    from agentloom.core.results import StepStatus, WorkflowStatus
+    from agentloom.providers.base import BaseProvider, ProviderResponse
+    from agentloom.providers.gateway import ProviderGateway
+
+    class FakeProvider(BaseProvider):
+        name = "fake"
+        async def complete(self, messages, model, **kwargs):
+            return ProviderResponse(content="fake-output", model=model, provider="fake")
+        async def stream(self, *a, **kw):
+            raise NotImplementedError
+        def supports_model(self, model):
+            return True
+
+    def _gw():
+        gw = ProviderGateway()
+        gw.register(FakeProvider(), priority=0)
+        return gw
+
+    def _wf():
+        return WorkflowDefinition(
+            name="approval-k8s",
+            config=WorkflowConfig(provider="fake", model="fake"),
+            state={"input": "hello"},
+            steps=[
+                StepDefinition(id="draft", type=StepType.LLM_CALL,
+                               prompt="Draft: {state.input}", output="draft_text"),
+                StepDefinition(id="approve", type=StepType.APPROVAL_GATE,
+                               depends_on=["draft"], output="decision"),
+                StepDefinition(id="send", type=StepType.LLM_CALL,
+                               depends_on=["approve"],
+                               prompt="Send: {state.draft_text}", output="result"),
+            ],
+        )
+
+    async def main():
+        with tempfile.TemporaryDirectory() as cp_dir:
+            ckpt = FileCheckpointer(checkpoint_dir=Path(cp_dir))
+
+            print("[1/3] Running workflow (should pause at approval gate)...")
+            eng = WorkflowEngine(workflow=_wf(), provider_gateway=_gw(),
+                                 checkpointer=ckpt, run_id="k8s-approval")
+            r = await eng.run()
+            assert r.status == WorkflowStatus.PAUSED, f"Expected PAUSED, got {r.status}"
+            assert r.step_results["approve"].status == StepStatus.PAUSED
+            print("  OK: paused at approval gate")
+
+            print("[2/3] Resuming with approval...")
+            data = await ckpt.load("k8s-approval")
+            resumed = await WorkflowEngine.from_checkpoint(
+                checkpoint_data=data, checkpointer=ckpt, provider_gateway=_gw(),
+                approval_decisions={"approve": "approved"})
+            r2 = await resumed.run()
+            assert r2.status == WorkflowStatus.SUCCESS, f"Expected SUCCESS, got {r2.status}"
+            assert r2.final_state.get("decision") == "approved"
+            print("  OK: completed with decision=approved")
+
+            print("[3/3] Verifying final checkpoint...")
+            final = await ckpt.load("k8s-approval")
+            assert final.status == "success"
+            assert final.paused_step_id is None
+            print("  OK: checkpoint updated to success")
+
+        print("\nAll K8s approval gate validations passed!")
+
+    import anyio
+    anyio.run(main)
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: approval-gate-smoke
+  namespace: agentloom
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  activeDeadlineSeconds: 120
+  template:
+    spec:
+      serviceAccountName: agentloom
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: runner
+          image: agentloom:dev
+          imagePullPolicy: Never
+          command: ["python3"]
+          args: ["/scripts/validate_approval_gate.py"]
+          env:
+            - name: UV_CACHE_DIR
+              value: /tmp/.uv-cache
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 50m
+            limits:
+              memory: 128Mi
+          securityContext:
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: script
+          configMap:
+            name: approval-gate-script

--- a/deploy/k8s/examples/pause-resume-job.yaml
+++ b/deploy/k8s/examples/pause-resume-job.yaml
@@ -123,7 +123,7 @@ spec:
         - name: runner
           image: agentloom:dev
           imagePullPolicy: Never
-          command: ["/build/.venv/bin/python"]
+          command: ["python3"]
           args: ["/scripts/validate_pause_resume.py"]
           env:
             - name: UV_CACHE_DIR

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,19 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Added
 
+- **Approval gate step type** — human-in-the-loop decision point (#41)
+    - `StepType.APPROVAL_GATE` pauses the workflow and waits for human approval or rejection
+    - Decision injected via `_approval.<step_id>` state key on resume
+    - `--approve` / `--reject` flags on `agentloom resume`
+    - `timeout_seconds` and `on_timeout` fields for automatic resolution
+    - Example workflow (29), validation script, and K8s smoke job
+- **Workflow pause mechanism** — foundation for human-in-the-loop (#40)
+    - `PauseRequestedError` exception for step executors to signal a pause
+    - `StepStatus.PAUSED` and `WorkflowStatus.PAUSED` status values
+    - Engine catches pause requests, saves checkpoint with `status=paused` and `paused_step_id`, and returns cleanly
+    - Resume from paused checkpoint skips completed steps and re-runs the paused step
+    - CLI treats paused workflows as non-error (exit code 0)
+    - Functional validation script and K8s smoke job
 - **Pluggable checkpoint backends** with `BaseCheckpointer` protocol and `FileCheckpointer` default (#78)
     - `CheckpointData` model with full workflow state serialization
     - Engine integration: auto `run_id`, checkpoint on completion/failure, graceful I/O error handling

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,7 @@ All notable changes to this project are documented here. The format follows [Kee
     - `StepType.APPROVAL_GATE` pauses the workflow and waits for human approval or rejection
     - Decision injected via `_approval.<step_id>` state key on resume
     - `--approve` / `--reject` flags on `agentloom resume`
-    - `timeout_seconds` and `on_timeout` fields for automatic resolution
+    - `timeout_seconds` and `on_timeout` schema fields (consumed by webhook callback server in #42)
     - Example workflow (29), validation script, and K8s smoke job
 - **Workflow pause mechanism** — foundation for human-in-the-loop (#40)
     - `PauseRequestedError` exception for step executors to signal a pause

--- a/examples/29_approval_gate.yaml
+++ b/examples/29_approval_gate.yaml
@@ -1,0 +1,39 @@
+name: approval-gate-demo
+description: >
+  Demonstrates the approval_gate step type.  The workflow drafts an email,
+  pauses for human approval, then formats the final version.
+
+  Usage:
+    agentloom run examples/29_approval_gate.yaml --checkpoint -s topic="project update"
+    agentloom runs                          # shows status: paused
+    agentloom resume <run_id> --approve     # or --reject
+    agentloom runs                          # shows status: success
+
+config:
+  provider: openai
+  model: gpt-4o-mini
+
+state:
+  topic: quarterly results
+
+steps:
+  - id: draft
+    type: llm_call
+    prompt: "Draft a short professional email about: {state.topic}"
+    output: draft_text
+
+  - id: approve
+    type: approval_gate
+    depends_on: [draft]
+    timeout_seconds: 3600
+    on_timeout: reject
+    output: decision
+
+  - id: finalise
+    type: llm_call
+    depends_on: [approve]
+    prompt: >
+      The reviewer's decision was: {state.decision}.
+      Original draft: {state.draft_text}
+      If approved, polish the draft. If rejected, explain that the email was discarded.
+    output: result

--- a/examples/29_approval_gate.yaml
+++ b/examples/29_approval_gate.yaml
@@ -25,8 +25,8 @@ steps:
   - id: approve
     type: approval_gate
     depends_on: [draft]
-    timeout_seconds: 3600
-    on_timeout: reject
+    timeout_seconds: 3600      # enforced by callback server (#42)
+    on_timeout: reject         # auto-decision when timeout expires (#42)
     output: decision
 
   - id: finalise

--- a/scripts/audit_approval_gate.py
+++ b/scripts/audit_approval_gate.py
@@ -1,0 +1,651 @@
+#!/usr/bin/env python3
+"""
+Approval Gate Implementation Audit for AgentLoom (Issue #41).
+
+Validates the approval gate step type across all layers:
+  1. Source contracts  — enum, model fields, executor, registry, engine, CLI
+  2. Test coverage     — required test classes and scenarios
+  3. Integration       — validation script, K8s manifest, example workflow
+  4. Runtime           — exercises pause → approve and pause → reject cycles
+
+Run:
+    python scripts/audit_approval_gate.py          # from repo root
+    python scripts/audit_approval_gate.py -v       # verbose (show passing checks)
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src" / "agentloom"
+TESTS = ROOT / "tests"
+
+_pass_count = 0
+_fail_count = 0
+_skip_count = 0
+_verbose = False
+
+
+def _green(t: str) -> str:
+    return f"\033[92m{t}\033[0m"
+
+
+def _red(t: str) -> str:
+    return f"\033[91m{t}\033[0m"
+
+
+def _yellow(t: str) -> str:
+    return f"\033[93m{t}\033[0m"
+
+
+def _bold(t: str) -> str:
+    return f"\033[1m{t}\033[0m"
+
+
+def _header(title: str) -> None:
+    print(f"\n{'─' * 60}")
+    print(f"  {_bold(title)}")
+    print(f"{'─' * 60}")
+
+
+def _pass(msg: str) -> None:
+    global _pass_count
+    _pass_count += 1
+    if _verbose:
+        print(f"  {_green('✓')} {msg}")
+
+
+def _fail(msg: str, detail: str = "") -> None:
+    global _fail_count
+    _fail_count += 1
+    print(f"  {_red('✗')} {msg}")
+    if detail:
+        for line in detail.strip().splitlines():
+            print(f"      {line}")
+
+
+def _skip(msg: str) -> None:
+    global _skip_count
+    _skip_count += 1
+    print(f"  {_yellow('○')} {msg}")
+
+
+def _read(path: Path) -> str:
+    return path.read_text() if path.is_file() else ""
+
+
+def _contains(text: str, *needles: str) -> bool:
+    return all(n in text for n in needles)
+
+
+# ────────────────────────────────────────────────────────────
+# Phase 1: Source contracts
+# ────────────────────────────────────────────────────────────
+
+
+def audit_step_type_enum() -> None:
+    _header("StepType enum")
+
+    src = _read(SRC / "core" / "models.py")
+
+    if 'APPROVAL_GATE = "approval_gate"' in src:
+        _pass("APPROVAL_GATE value in StepType enum")
+    else:
+        _fail("APPROVAL_GATE missing from StepType enum")
+
+
+def audit_step_definition_fields() -> None:
+    _header("StepDefinition approval gate fields")
+
+    src = _read(SRC / "core" / "models.py")
+
+    if "timeout_seconds" in src and "int | None" in src:
+        _pass("timeout_seconds field defined (int | None)")
+    else:
+        _fail("timeout_seconds field missing on StepDefinition")
+
+    if "on_timeout" in src:
+        _pass("on_timeout field defined")
+    else:
+        _fail("on_timeout field missing on StepDefinition")
+
+    if '"approve"' in src and '"reject"' in src:
+        _pass('on_timeout accepts "approve" and "reject"')
+    else:
+        _fail("on_timeout should be Literal['approve', 'reject']")
+
+
+def audit_executor() -> None:
+    _header("ApprovalGateStep executor")
+
+    path = SRC / "steps" / "approval_gate.py"
+    src = _read(path)
+
+    if not src:
+        _fail("src/agentloom/steps/approval_gate.py does not exist")
+        return
+
+    _pass("approval_gate.py exists")
+
+    if "class ApprovalGateStep" in src and "BaseStep" in src:
+        _pass("ApprovalGateStep inherits from BaseStep")
+    else:
+        _fail("ApprovalGateStep class or BaseStep inheritance missing")
+
+    if "async def execute" in src:
+        _pass("execute() method defined")
+    else:
+        _fail("execute() method missing")
+
+    if "_approval." in src and "state_manager.get" in src:
+        _pass("Reads decision from _approval.{step_id} in state")
+    else:
+        _fail("Should read decision from _approval.{step_id}")
+
+    if "PauseRequestedError" in src:
+        _pass("Raises PauseRequestedError when no decision")
+    else:
+        _fail("Should raise PauseRequestedError on first execution")
+
+    if "StepError" in src:
+        _pass("Raises StepError on invalid decision")
+    else:
+        _fail("Should validate decision value")
+
+    if '"approved"' in src and '"rejected"' in src:
+        _pass('Accepts "approved" and "rejected" decisions')
+    else:
+        _fail("Should accept approved/rejected decisions")
+
+    if "APPROVAL REQUIRED" in src and "stderr" in src:
+        _pass("Prints instructions to stderr on pause")
+    else:
+        _fail("Should print resume instructions to stderr")
+
+    if "step.output" in src and "state_manager.set" in src:
+        _pass("Stores decision in output state variable")
+    else:
+        _fail("Should store decision via step.output")
+
+
+def audit_registry() -> None:
+    _header("Step registry")
+
+    src = _read(SRC / "steps" / "registry.py")
+
+    if "ApprovalGateStep" in src:
+        _pass("ApprovalGateStep imported in registry")
+    else:
+        _fail("ApprovalGateStep not imported in registry.py")
+
+    if "APPROVAL_GATE" in src:
+        _pass("APPROVAL_GATE registered in create_default_registry()")
+    else:
+        _fail("APPROVAL_GATE not registered")
+
+
+def audit_engine() -> None:
+    _header("Engine from_checkpoint() approval support")
+
+    src = _read(SRC / "core" / "engine.py")
+
+    if "approval_decisions" in src:
+        _pass("approval_decisions parameter on from_checkpoint()")
+    else:
+        _fail("approval_decisions parameter missing from from_checkpoint()")
+        return
+
+    if "dict[str, str]" in src and "approval_decisions" in src:
+        _pass("approval_decisions typed as dict[str, str]")
+    else:
+        _fail("approval_decisions should be dict[str, str]")
+
+    if "_approval." in src and "state_manager.set" in src:
+        _pass("Injects decisions into state as _approval.{step_id}")
+    else:
+        _fail("Should inject decisions into state via _approval.{step_id}")
+
+
+def audit_cli() -> None:
+    _header("CLI resume --approve/--reject")
+
+    src = _read(SRC / "cli" / "resume.py")
+
+    if "--approve" in src:
+        _pass("--approve flag defined")
+    else:
+        _fail("--approve flag missing from resume command")
+
+    if "--reject" in src:
+        _pass("--reject flag defined")
+    else:
+        _fail("--reject flag missing from resume command")
+
+    if "approve" in src and "reject" in src and "Cannot use" in src:
+        _pass("Mutual exclusion validated (--approve + --reject)")
+    else:
+        _fail("Should validate mutual exclusion of --approve and --reject")
+
+    if "approval_decisions" in src:
+        _pass("Builds approval_decisions dict from flags")
+    else:
+        _fail("Should build approval_decisions and pass to from_checkpoint()")
+
+    if "paused_step_id" in src and "decision" in src:
+        _pass("Maps decision to paused_step_id from checkpoint")
+    else:
+        _fail("Should use checkpoint.paused_step_id as decision key")
+
+
+# ────────────────────────────────────────────────────────────
+# Phase 2: Test coverage
+# ────────────────────────────────────────────────────────────
+
+
+def audit_unit_tests() -> None:
+    _header("Unit tests (steps/test_approval_gate.py)")
+
+    src = _read(TESTS / "steps" / "test_approval_gate.py")
+
+    if not src:
+        _fail("tests/steps/test_approval_gate.py does not exist")
+        return
+
+    _pass("test_approval_gate.py exists")
+
+    required = [
+        "test_pauses_without_decision",
+        "test_returns_approved",
+        "test_returns_rejected",
+        "test_invalid_decision_raises",
+        "test_stores_output_in_state",
+    ]
+    found = [t for t in required if f"def {t}" in src]
+    missing = [t for t in required if t not in found]
+
+    if len(found) == len(required):
+        _pass(f"All {len(required)} required unit test methods present")
+    else:
+        detail = "\n".join(f"Missing: {m}" for m in missing)
+        _fail(f"{len(found)}/{len(required)} unit tests found", detail)
+
+
+def audit_integration_tests() -> None:
+    _header("Integration tests (core/test_engine_approval.py)")
+
+    src = _read(TESTS / "core" / "test_engine_approval.py")
+
+    if not src:
+        _fail("tests/core/test_engine_approval.py does not exist")
+        return
+
+    _pass("test_engine_approval.py exists")
+
+    required_classes = [
+        ("TestApprovalGatePause", "pause behaviour"),
+        ("TestApprovalGateResume", "resume with decisions"),
+    ]
+    for cls, desc in required_classes:
+        if f"class {cls}" in src:
+            _pass(f"{cls} — {desc}")
+        else:
+            _fail(f"Missing test class: {cls} ({desc})")
+
+    required_tests = [
+        "test_approval_gate_pauses_workflow",
+        "test_approval_gate_saves_checkpoint",
+        "test_resume_with_approve",
+        "test_resume_with_reject",
+        "test_downstream_reads_decision",
+        "test_resume_skips_completed_steps",
+        "test_resume_without_decision_pauses_again",
+    ]
+    found = [t for t in required_tests if f"def {t}" in src]
+    missing = [t for t in required_tests if t not in found]
+
+    if len(found) == len(required_tests):
+        _pass(f"All {len(required_tests)} integration test methods present")
+    else:
+        detail = "\n".join(f"Missing: {m}" for m in missing)
+        _fail(f"{len(found)}/{len(required_tests)} integration tests found", detail)
+
+
+def audit_cli_tests() -> None:
+    _header("CLI tests (cli/test_resume.py)")
+
+    src = _read(TESTS / "cli" / "test_resume.py")
+
+    if "TestResumeApproval" in src:
+        _pass("TestResumeApproval class present")
+    else:
+        _fail("TestResumeApproval class missing in test_resume.py")
+
+    cli_tests = [
+        "test_resume_approve_flag",
+        "test_resume_reject_flag",
+        "test_approve_reject_mutual_exclusion",
+    ]
+    found = [t for t in cli_tests if f"def {t}" in src]
+    missing = [t for t in cli_tests if t not in found]
+
+    if len(found) == len(cli_tests):
+        _pass(f"All {len(cli_tests)} CLI test methods present")
+    else:
+        detail = "\n".join(f"Missing: {m}" for m in missing)
+        _fail(f"{len(found)}/{len(cli_tests)} CLI tests found", detail)
+
+
+# ────────────────────────────────────────────────────────────
+# Phase 3: Integration artefacts
+# ────────────────────────────────────────────────────────────
+
+
+def audit_artefacts() -> None:
+    _header("Integration artefacts")
+
+    # Validation script
+    script = ROOT / "scripts" / "validate_approval_gate.py"
+    script_src = _read(script)
+    if script_src:
+        _pass("scripts/validate_approval_gate.py exists")
+    else:
+        _fail("Validation script missing")
+
+    if script_src and "anyio.run" in script_src:
+        _pass("Validation script uses anyio.run")
+    elif script_src:
+        _fail("Validation script should use anyio.run")
+
+    if script_src and "asyncio.run" not in script_src:
+        _pass("No asyncio.run in validation script")
+    elif script_src:
+        _fail("Validation script should not use asyncio.run")
+
+    for keyword in ("approved", "rejected", "checkpoint", "resume"):
+        if script_src and keyword in script_src.lower():
+            _pass(f"Validation script covers: {keyword}")
+        elif script_src:
+            _fail(f"Validation script should cover: {keyword}")
+
+    # K8s manifest
+    k8s = ROOT / "deploy" / "k8s" / "examples" / "approval-gate-job.yaml"
+    k8s_src = _read(k8s)
+    if k8s_src:
+        _pass("K8s approval-gate-job.yaml exists")
+    else:
+        _fail("K8s smoke job manifest missing")
+
+    if k8s_src and "ConfigMap" in k8s_src and "Job" in k8s_src:
+        _pass("K8s manifest has ConfigMap + Job")
+    elif k8s_src:
+        _fail("K8s manifest should define ConfigMap and Job")
+
+    if k8s_src and "anyio" in k8s_src:
+        _pass("K8s script uses anyio")
+    elif k8s_src:
+        _fail("K8s script should use anyio")
+
+    # Example workflow
+    example = ROOT / "examples" / "29_approval_gate.yaml"
+    example_src = _read(example)
+    if example_src:
+        _pass("examples/29_approval_gate.yaml exists")
+    else:
+        _fail("Example workflow missing")
+
+    if example_src and "approval_gate" in example_src:
+        _pass("Example uses approval_gate step type")
+    elif example_src:
+        _fail("Example should use approval_gate step type")
+
+    if example_src and "timeout_seconds" in example_src:
+        _pass("Example includes timeout_seconds field")
+    elif example_src:
+        _fail("Example should demonstrate timeout_seconds")
+
+    if example_src and "on_timeout" in example_src:
+        _pass("Example includes on_timeout field")
+    elif example_src:
+        _fail("Example should demonstrate on_timeout")
+
+
+# ────────────────────────────────────────────────────────────
+# Phase 4: Runtime validation
+# ────────────────────────────────────────────────────────────
+
+
+def audit_runtime() -> None:
+    _header("Runtime validation (live approval gate cycles)")
+
+    try:
+        import anyio
+
+        from agentloom.checkpointing.file import FileCheckpointer
+        from agentloom.core.engine import WorkflowEngine
+        from agentloom.core.models import (
+            StepDefinition,
+            StepType,
+            WorkflowConfig,
+            WorkflowDefinition,
+        )
+        from agentloom.core.results import StepStatus, WorkflowStatus
+        from agentloom.providers.base import BaseProvider, ProviderResponse
+        from agentloom.providers.gateway import ProviderGateway
+    except ImportError as e:
+        _skip(f"Cannot import agentloom: {e}")
+        return
+
+    class _FakeProvider(BaseProvider):
+        name = "fake"
+
+        async def complete(self, messages, model, **kwargs):  # noqa: ANN001,ANN003
+            return ProviderResponse(content="fake", model=model, provider="fake")
+
+        async def stream(self, *a, **kw):  # noqa: ANN002,ANN003
+            raise NotImplementedError
+
+        def supports_model(self, model: str) -> bool:
+            return True
+
+    def _gw() -> ProviderGateway:
+        gw = ProviderGateway()
+        gw.register(_FakeProvider(), priority=0)
+        return gw
+
+    workflow = WorkflowDefinition(
+        name="audit-approval",
+        config=WorkflowConfig(provider="fake", model="fake"),
+        state={"input": "hello"},
+        steps=[
+            StepDefinition(
+                id="draft",
+                type=StepType.LLM_CALL,
+                prompt="Draft: {state.input}",
+                output="draft_text",
+            ),
+            StepDefinition(
+                id="approve",
+                type=StepType.APPROVAL_GATE,
+                depends_on=["draft"],
+                output="decision",
+            ),
+            StepDefinition(
+                id="send",
+                type=StepType.LLM_CALL,
+                depends_on=["approve"],
+                prompt="Send: {state.draft_text}",
+                output="result",
+            ),
+        ],
+    )
+
+    async def _run_audit() -> None:
+        with tempfile.TemporaryDirectory() as cp_dir:
+            ckpt = FileCheckpointer(checkpoint_dir=Path(cp_dir))
+
+            # ── Pause at approval gate ─────────────────────────
+            engine = WorkflowEngine(
+                workflow=workflow,
+                provider_gateway=_gw(),
+                checkpointer=ckpt,
+                run_id="audit-approval",
+            )
+            r1 = await engine.run()
+
+            if r1.status == WorkflowStatus.PAUSED:
+                _pass("Runtime: workflow paused at approval gate")
+            else:
+                _fail(f"Runtime: expected PAUSED, got {r1.status.value}")
+                return
+
+            step_d = r1.step_results.get("draft")
+            if step_d and step_d.status == StepStatus.SUCCESS:
+                _pass("Runtime: draft completed before gate")
+            else:
+                _fail("Runtime: draft should be SUCCESS")
+
+            step_a = r1.step_results.get("approve")
+            if step_a and step_a.status == StepStatus.PAUSED:
+                _pass("Runtime: approve step has PAUSED status")
+            else:
+                _fail("Runtime: approve should be PAUSED")
+
+            # ── Verify checkpoint ──────────────────────────────
+            loaded = await ckpt.load("audit-approval")
+            if loaded.status == "paused" and loaded.paused_step_id == "approve":
+                _pass("Runtime: checkpoint paused at approve")
+            else:
+                _fail(
+                    f"Runtime: checkpoint status={loaded.status},"
+                    f" paused_step_id={loaded.paused_step_id}"
+                )
+
+            # ── Resume with approval ───────────────────────────
+            data = await ckpt.load("audit-approval")
+            resumed = await WorkflowEngine.from_checkpoint(
+                checkpoint_data=data,
+                checkpointer=ckpt,
+                provider_gateway=_gw(),
+                approval_decisions={"approve": "approved"},
+            )
+            r2 = await resumed.run()
+
+            if r2.status == WorkflowStatus.SUCCESS:
+                _pass("Runtime: workflow completed after approval")
+            else:
+                _fail(f"Runtime: expected SUCCESS, got {r2.status.value}")
+
+            if r2.final_state.get("decision") == "approved":
+                _pass("Runtime: decision=approved in final state")
+            else:
+                _fail(f"Runtime: decision={r2.final_state.get('decision')}")
+
+            if r2.step_results.get("send", None):
+                if r2.step_results["send"].status == StepStatus.SUCCESS:
+                    _pass("Runtime: send step completed after approval")
+                else:
+                    _fail("Runtime: send should be SUCCESS")
+            else:
+                _fail("Runtime: send step missing from results")
+
+            # ── Resume with rejection ──────────────────────────
+            engine2 = WorkflowEngine(
+                workflow=workflow,
+                provider_gateway=_gw(),
+                checkpointer=ckpt,
+                run_id="audit-reject",
+            )
+            await engine2.run()
+
+            data2 = await ckpt.load("audit-reject")
+            resumed2 = await WorkflowEngine.from_checkpoint(
+                checkpoint_data=data2,
+                checkpointer=ckpt,
+                provider_gateway=_gw(),
+                approval_decisions={"approve": "rejected"},
+            )
+            r3 = await resumed2.run()
+
+            if r3.status == WorkflowStatus.SUCCESS:
+                _pass("Runtime: workflow completed after rejection")
+            else:
+                _fail(f"Runtime: expected SUCCESS after reject, got {r3.status.value}")
+
+            if r3.final_state.get("decision") == "rejected":
+                _pass("Runtime: decision=rejected in final state")
+            else:
+                _fail(f"Runtime: decision={r3.final_state.get('decision')}")
+
+            # ── Final checkpoint status ────────────────────────
+            final = await ckpt.load("audit-approval")
+            if final.status == "success" and final.paused_step_id is None:
+                _pass("Runtime: final checkpoint is success, no paused_step_id")
+            else:
+                _fail(f"Runtime: final status={final.status}")
+
+    anyio.run(_run_audit)
+
+
+# ────────────────────────────────────────────────────────────
+# Main
+# ────────────────────────────────────────────────────────────
+
+
+def main() -> int:
+    global _verbose
+
+    parser = argparse.ArgumentParser(description="Audit approval gate implementation")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Show passing checks")
+    parser.add_argument(
+        "--skip-runtime",
+        action="store_true",
+        help="Skip runtime validation",
+    )
+    args = parser.parse_args()
+    _verbose = args.verbose
+
+    print(_bold("\n  AgentLoom — Approval Gate Audit (Issue #41)"))
+    print(f"  {'=' * 48}")
+
+    # Phase 1
+    audit_step_type_enum()
+    audit_step_definition_fields()
+    audit_executor()
+    audit_registry()
+    audit_engine()
+    audit_cli()
+
+    # Phase 2
+    audit_unit_tests()
+    audit_integration_tests()
+    audit_cli_tests()
+
+    # Phase 3
+    audit_artefacts()
+
+    # Phase 4
+    if not args.skip_runtime:
+        audit_runtime()
+    else:
+        _skip("Runtime validation skipped (--skip-runtime)")
+
+    # Summary
+    total = _pass_count + _fail_count + _skip_count
+    print(f"\n{'=' * 60}")
+    print(
+        f"  {_bold('Results')}: {_green(f'{_pass_count} passed')}  "
+        f"{_red(f'{_fail_count} failed') if _fail_count else f'{_fail_count} failed'}  "
+        f"{_yellow(f'{_skip_count} skipped') if _skip_count else f'{_skip_count} skipped'}  "
+        f"({total} total)"
+    )
+    print(f"{'=' * 60}\n")
+
+    return 1 if _fail_count > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate_approval_gate.py
+++ b/scripts/validate_approval_gate.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Functional validation of the approval gate step type.
+
+Exercises the full flow programmatically:
+  1. Run a workflow with an approval gate → verify it pauses
+  2. Verify checkpoint saved with status=paused, paused_step_id=approve
+  3. Resume with decision=approved → verify workflow completes
+  4. Run again → pause → resume with decision=rejected → verify rejected
+
+Can be run standalone:
+    uv run python scripts/validate_approval_gate.py
+Or inside Docker:
+    docker run --rm agentloom:dev python scripts/validate_approval_gate.py
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+from agentloom.checkpointing.file import FileCheckpointer
+from agentloom.core.engine import WorkflowEngine
+from agentloom.core.models import (
+    StepDefinition,
+    StepType,
+    WorkflowConfig,
+    WorkflowDefinition,
+)
+from agentloom.core.results import StepStatus, WorkflowStatus
+from agentloom.providers.base import BaseProvider, ProviderResponse
+from agentloom.providers.gateway import ProviderGateway
+
+
+class FakeProvider(BaseProvider):
+    """Minimal provider that returns a fixed response."""
+
+    name = "fake"
+
+    async def complete(self, messages, model, **kwargs):  # noqa: ANN001,ANN003
+        return ProviderResponse(content="fake-output", model=model, provider="fake")
+
+    async def stream(self, *a, **kw):  # noqa: ANN002,ANN003
+        raise NotImplementedError
+
+    def supports_model(self, model: str) -> bool:
+        return True
+
+
+def _gateway() -> ProviderGateway:
+    gw = ProviderGateway()
+    gw.register(FakeProvider(), priority=0)
+    return gw
+
+
+def _workflow() -> WorkflowDefinition:
+    return WorkflowDefinition(
+        name="approval-validate",
+        config=WorkflowConfig(provider="fake", model="fake"),
+        state={"input": "hello"},
+        steps=[
+            StepDefinition(
+                id="draft",
+                type=StepType.LLM_CALL,
+                prompt="Draft: {state.input}",
+                output="draft_text",
+            ),
+            StepDefinition(
+                id="approve",
+                type=StepType.APPROVAL_GATE,
+                depends_on=["draft"],
+                output="decision",
+            ),
+            StepDefinition(
+                id="send",
+                type=StepType.LLM_CALL,
+                depends_on=["approve"],
+                prompt="Send ({state.decision}): {state.draft_text}",
+                output="result",
+            ),
+        ],
+    )
+
+
+def _ok(msg: str) -> None:
+    print(f"  \u2713 {msg}")
+
+
+def _fail(msg: str) -> None:
+    print(f"  \u2717 {msg}")
+    sys.exit(1)
+
+
+async def main() -> None:
+    with tempfile.TemporaryDirectory() as cp_dir:
+        checkpointer = FileCheckpointer(checkpoint_dir=Path(cp_dir))
+
+        # ── Test 1: Run → should pause at approval gate ────────────
+        print("\n[1/5] Running workflow (should pause at approval gate)...")
+        engine = WorkflowEngine(
+            workflow=_workflow(),
+            provider_gateway=_gateway(),
+            checkpointer=checkpointer,
+            run_id="approval-validate",
+        )
+        result = await engine.run()
+
+        if result.status == WorkflowStatus.PAUSED:
+            _ok(f"Workflow paused (status={result.status.value})")
+        else:
+            _fail(f"Expected PAUSED, got {result.status.value}")
+
+        if result.step_results["draft"].status == StepStatus.SUCCESS:
+            _ok("draft step completed before pause")
+        else:
+            _fail("draft step should be SUCCESS")
+
+        if result.step_results["approve"].status == StepStatus.PAUSED:
+            _ok("approve step has PAUSED status")
+        else:
+            _fail(f"approve step should be PAUSED, got {result.step_results['approve'].status}")
+
+        # ── Test 2: Verify checkpoint ──────────────────────────────
+        print("\n[2/5] Verifying checkpoint...")
+        loaded = await checkpointer.load("approval-validate")
+
+        if loaded.status == "paused" and loaded.paused_step_id == "approve":
+            _ok("Checkpoint: status=paused, paused_step_id=approve")
+        else:
+            _fail(f"Checkpoint: status={loaded.status}, paused_step_id={loaded.paused_step_id}")
+
+        if "draft" in loaded.completed_steps and "approve" not in loaded.completed_steps:
+            _ok("Completed steps correct (draft in, approve out)")
+        else:
+            _fail(f"Completed steps: {loaded.completed_steps}")
+
+        # ── Test 3: Resume with --approve ──────────────────────────
+        print("\n[3/5] Resuming with decision=approved...")
+        data = await checkpointer.load("approval-validate")
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=data,
+            checkpointer=checkpointer,
+            provider_gateway=_gateway(),
+            approval_decisions={"approve": "approved"},
+        )
+        result2 = await resumed.run()
+
+        if result2.status == WorkflowStatus.SUCCESS:
+            _ok("Workflow completed after approval")
+        else:
+            _fail(f"Expected SUCCESS, got {result2.status.value}")
+
+        if result2.final_state.get("decision") == "approved":
+            _ok("Decision stored in state: approved")
+        else:
+            _fail(f"Decision in state: {result2.final_state.get('decision')}")
+
+        if result2.step_results["send"].status == StepStatus.SUCCESS:
+            _ok("send step completed after approval")
+        else:
+            _fail("send step should be SUCCESS")
+
+        # ── Test 4: Run again → pause → resume with --reject ──────
+        print("\n[4/5] Running again and resuming with decision=rejected...")
+        engine2 = WorkflowEngine(
+            workflow=_workflow(),
+            provider_gateway=_gateway(),
+            checkpointer=checkpointer,
+            run_id="approval-reject",
+        )
+        await engine2.run()
+
+        data2 = await checkpointer.load("approval-reject")
+        resumed2 = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=data2,
+            checkpointer=checkpointer,
+            provider_gateway=_gateway(),
+            approval_decisions={"approve": "rejected"},
+        )
+        result3 = await resumed2.run()
+
+        if result3.status == WorkflowStatus.SUCCESS:
+            _ok("Workflow completed after rejection")
+        else:
+            _fail(f"Expected SUCCESS, got {result3.status.value}")
+
+        if result3.final_state.get("decision") == "rejected":
+            _ok("Decision stored in state: rejected")
+        else:
+            _fail(f"Decision in state: {result3.final_state.get('decision')}")
+
+        # ── Test 5: Final checkpoint status ────────────────────────
+        print("\n[5/5] Verifying final checkpoints...")
+        final1 = await checkpointer.load("approval-validate")
+        final2 = await checkpointer.load("approval-reject")
+
+        if final1.status == "success" and final2.status == "success":
+            _ok("Both checkpoints updated to success")
+        else:
+            _fail(f"Checkpoint statuses: {final1.status}, {final2.status}")
+
+        if final1.paused_step_id is None and final2.paused_step_id is None:
+            _ok("No paused_step_id in final checkpoints")
+        else:
+            _fail("paused_step_id should be cleared")
+
+        print("\n" + "=" * 50)
+        print("  All approval gate validations passed!")
+        print("=" * 50 + "\n")
+
+
+if __name__ == "__main__":
+    import anyio
+
+    anyio.run(main)

--- a/src/agentloom/cli/resume.py
+++ b/src/agentloom/cli/resume.py
@@ -75,7 +75,13 @@ async def _resume_async(
 
     # Build approval decisions map for the paused step
     approval_decisions: dict[str, str] = {}
-    if decision and checkpoint_data.paused_step_id:
+    if decision:
+        if checkpoint_data.status != "paused" or not checkpoint_data.paused_step_id:
+            typer.echo(
+                f"Run '{run_id}' is not paused at an approval gate.",
+                err=True,
+            )
+            raise typer.Exit(1)
         approval_decisions[checkpoint_data.paused_step_id] = decision
 
     if decision:

--- a/src/agentloom/cli/resume.py
+++ b/src/agentloom/cli/resume.py
@@ -17,12 +17,34 @@ def resume(
         None, "--provider", "-p", help="Override default provider."
     ),
     model: str | None = typer.Option(None, "--model", "-m", help="Override default model."),
+    approve: bool = typer.Option(False, "--approve", help="Approve a pending approval gate."),
+    reject: bool = typer.Option(False, "--reject", help="Reject a pending approval gate."),
     lite: bool = typer.Option(False, "--lite", help="Run in lite mode (no observability)."),
     output_json: bool = typer.Option(False, "--json", help="Output results as JSON."),
     stream: bool = typer.Option(False, "--stream", help="Stream LLM output in real-time."),
 ) -> None:
     """Resume a paused or failed workflow from its last checkpoint."""
-    anyio.run(_resume_async, run_id, checkpoint_dir, provider, model, lite, output_json, stream)
+    if approve and reject:
+        typer.echo("Cannot use --approve and --reject together.", err=True)
+        raise typer.Exit(1)
+
+    decision: str | None = None
+    if approve:
+        decision = "approved"
+    elif reject:
+        decision = "rejected"
+
+    anyio.run(
+        _resume_async,
+        run_id,
+        checkpoint_dir,
+        provider,
+        model,
+        decision,
+        lite,
+        output_json,
+        stream,
+    )
 
 
 async def _resume_async(
@@ -30,6 +52,7 @@ async def _resume_async(
     checkpoint_dir: str,
     provider_override: str | None,
     model_override: str | None,
+    decision: str | None,
     lite: bool,
     output_json: bool,
     stream: bool,
@@ -50,15 +73,27 @@ async def _resume_async(
         typer.echo(f"No checkpoint found for run '{run_id}'.", err=True)
         raise typer.Exit(1)
 
-    typer.echo(
-        f"Resuming workflow '{checkpoint_data.workflow_name}' "
-        f"(run {run_id}, status={checkpoint_data.status})"
-    )
+    # Build approval decisions map for the paused step
+    approval_decisions: dict[str, str] = {}
+    if decision and checkpoint_data.paused_step_id:
+        approval_decisions[checkpoint_data.paused_step_id] = decision
+
+    if decision:
+        typer.echo(
+            f"Resuming workflow '{checkpoint_data.workflow_name}' "
+            f"(run {run_id}, decision={decision} for step '{checkpoint_data.paused_step_id}')"
+        )
+    else:
+        typer.echo(
+            f"Resuming workflow '{checkpoint_data.workflow_name}' "
+            f"(run {run_id}, status={checkpoint_data.status})"
+        )
 
     # Reconstruct engine
     engine = await WorkflowEngine.from_checkpoint(
         checkpoint_data=checkpoint_data,
         checkpointer=checkpointer,
+        approval_decisions=approval_decisions or None,
     )
 
     # Apply overrides

--- a/src/agentloom/core/engine.py
+++ b/src/agentloom/core/engine.py
@@ -142,11 +142,17 @@ class WorkflowEngine:
         step_registry: StepRegistry | None = None,
         observer: Any | None = None,
         on_stream_chunk: Callable[[str, str], None] | None = None,
+        approval_decisions: dict[str, str] | None = None,
     ) -> WorkflowEngine:
         """Reconstruct an engine from a checkpoint, ready to resume.
 
         The returned engine's :meth:`run` will skip already-completed steps
         and continue execution from where it left off.
+
+        Args:
+            approval_decisions: Optional map of ``step_id → "approved"|"rejected"``
+                injected into state so that paused approval gate steps can read
+                the human decision on re-execution.
         """
         workflow = WorkflowDefinition.model_validate(checkpoint_data.workflow_definition)
 
@@ -156,6 +162,11 @@ class WorkflowEngine:
         for step_id, result_data in checkpoint_data.step_results.items():
             result = StepResult.model_validate(result_data)
             await state_manager.set_step_result(step_id, result)
+
+        # Inject approval decisions so gate steps find them on re-execution
+        if approval_decisions:
+            for step_id, decision in approval_decisions.items():
+                await state_manager.set(f"_approval.{step_id}", decision)
 
         engine = cls(
             workflow=workflow,

--- a/src/agentloom/core/models.py
+++ b/src/agentloom/core/models.py
@@ -15,6 +15,7 @@ class StepType(StrEnum):
     TOOL = "tool"
     ROUTER = "router"
     SUBWORKFLOW = "subworkflow"
+    APPROVAL_GATE = "approval_gate"
 
 
 class Attachment(BaseModel):
@@ -76,6 +77,10 @@ class StepDefinition(BaseModel):
     # Subworkflow fields
     workflow_path: str | None = None
     workflow_inline: dict[str, Any] | None = None
+
+    # Approval gate fields
+    timeout_seconds: int | None = None
+    on_timeout: Literal["approve", "reject"] | None = None
 
     # Multimodal attachments (images, etc.)
     attachments: list[Attachment] = Field(default_factory=list)

--- a/src/agentloom/core/models.py
+++ b/src/agentloom/core/models.py
@@ -78,7 +78,7 @@ class StepDefinition(BaseModel):
     workflow_path: str | None = None
     workflow_inline: dict[str, Any] | None = None
 
-    # Approval gate fields
+    # Approval gate fields (timeout enforced by callback server — #42)
     timeout_seconds: int | None = None
     on_timeout: Literal["approve", "reject"] | None = None
 

--- a/src/agentloom/steps/approval_gate.py
+++ b/src/agentloom/steps/approval_gate.py
@@ -1,0 +1,57 @@
+"""Approval gate step executor — pauses for human decision."""
+
+from __future__ import annotations
+
+import sys
+import time
+
+from agentloom.core.results import StepResult, StepStatus
+from agentloom.exceptions import PauseRequestedError, StepError
+from agentloom.steps.base import BaseStep, StepContext
+
+
+class ApprovalGateStep(BaseStep):
+    """Pauses the workflow until a human approves or rejects.
+
+    On first execution the step raises ``PauseRequestedError`` so the
+    engine serializes the workflow state.  When the user resumes with
+    ``--approve`` or ``--reject``, the CLI injects the decision into
+    state at ``_approval.<step_id>`` and the step returns it as output.
+    """
+
+    async def execute(self, context: StepContext) -> StepResult:
+        step = context.step_definition
+        start = time.monotonic()
+
+        # Check whether a decision was injected into state on resume
+        decision = await context.state_manager.get(f"_approval.{step.id}")
+
+        if decision is None:
+            # First execution — print instructions and pause
+            print(
+                f"\n[APPROVAL REQUIRED] Step '{step.id}' is waiting for approval.\n"
+                f"  Resume with: agentloom resume <run_id> --approve\n"
+                f"  Or reject:   agentloom resume <run_id> --reject\n",
+                file=sys.stderr,
+            )
+            raise PauseRequestedError(step.id, f"Approval required at step '{step.id}'")
+
+        # Validate the decision value
+        if decision not in ("approved", "rejected"):
+            raise StepError(
+                step.id,
+                f"Invalid approval decision '{decision}'. Expected 'approved' or 'rejected'.",
+            )
+
+        duration = (time.monotonic() - start) * 1000
+
+        # Store the decision in the output state variable
+        if step.output:
+            await context.state_manager.set(step.output, decision)
+
+        return StepResult(
+            step_id=step.id,
+            status=StepStatus.SUCCESS,
+            output=decision,
+            duration_ms=duration,
+        )

--- a/src/agentloom/steps/registry.py
+++ b/src/agentloom/steps/registry.py
@@ -22,6 +22,7 @@ class StepRegistry:
 
 def create_default_registry() -> StepRegistry:
     """Create a registry with all built-in step types."""
+    from agentloom.steps.approval_gate import ApprovalGateStep
     from agentloom.steps.llm_call import LLMCallStep
     from agentloom.steps.router import RouterStep
     from agentloom.steps.subworkflow import SubworkflowStep
@@ -32,4 +33,5 @@ def create_default_registry() -> StepRegistry:
     registry.register(StepType.ROUTER, RouterStep)
     registry.register(StepType.TOOL, ToolStep)
     registry.register(StepType.SUBWORKFLOW, SubworkflowStep)
+    registry.register(StepType.APPROVAL_GATE, ApprovalGateStep)
     return registry

--- a/tests/cli/test_resume.py
+++ b/tests/cli/test_resume.py
@@ -385,6 +385,4 @@ class TestResumeApproval:
         )
 
         assert result.exit_code != 0
-        assert "not paused at an approval gate" in (
-            result.output + (result.stderr or "")
-        )
+        assert "not paused at an approval gate" in (result.output + (result.stderr or ""))

--- a/tests/cli/test_resume.py
+++ b/tests/cli/test_resume.py
@@ -375,3 +375,16 @@ class TestResumeApproval:
         assert "Cannot use --approve and --reject together" in (
             result.output + (result.stderr or "")
         )
+
+    def test_approve_on_non_paused_run_fails(self, tmp_path: Path) -> None:
+        _write_checkpoint(tmp_path, "not-paused", status="failed", paused_step_id=None)
+
+        result = runner.invoke(
+            app,
+            ["resume", "not-paused", "--checkpoint-dir", str(tmp_path), "--approve"],
+        )
+
+        assert result.exit_code != 0
+        assert "not paused at an approval gate" in (
+            result.output + (result.stderr or "")
+        )

--- a/tests/cli/test_resume.py
+++ b/tests/cli/test_resume.py
@@ -42,17 +42,22 @@ def _write_checkpoint(
     *,
     status: str = "failed",
     completed_steps: list[str] | None = None,
+    paused_step_id: str | None = None,
+    workflow: WorkflowDefinition | None = None,
+    state: dict | None = None,
+    step_results: dict | None = None,
 ) -> None:
     """Write a checkpoint file for testing."""
-    wf = _make_workflow()
+    wf = workflow or _make_workflow()
     data = CheckpointData(
         workflow_name=wf.name,
         run_id=run_id,
         workflow_definition=wf.model_dump(),
-        state={"input": "hello"},
-        step_results={},
+        state=state or {"input": "hello"},
+        step_results=step_results or {},
         completed_steps=completed_steps or [],
         status=status,
+        paused_step_id=paused_step_id,
         created_at="2026-04-12T18:00:00+00:00",
         updated_at="2026-04-12T18:00:01+00:00",
     )
@@ -224,3 +229,149 @@ class TestResumeCommand:
                 )
 
         assert result.exit_code != 0
+
+
+def _approval_workflow() -> WorkflowDefinition:
+    """Workflow with an approval gate."""
+    return WorkflowDefinition(
+        name="approval-cli-test",
+        config=WorkflowConfig(provider="mock", model="mock-model"),
+        state={"input": "hello"},
+        steps=[
+            StepDefinition(
+                id="draft",
+                type=StepType.LLM_CALL,
+                prompt="Draft: {state.input}",
+                output="draft_text",
+            ),
+            StepDefinition(
+                id="approve",
+                type=StepType.APPROVAL_GATE,
+                depends_on=["draft"],
+                output="decision",
+            ),
+            StepDefinition(
+                id="send",
+                type=StepType.LLM_CALL,
+                depends_on=["approve"],
+                prompt="Send: {state.draft_text}",
+                output="result",
+            ),
+        ],
+    )
+
+
+class TestResumeApproval:
+    def test_resume_approve_flag(self, tmp_path: Path) -> None:
+        wf = _approval_workflow()
+        _write_checkpoint(
+            tmp_path,
+            "approve-ok",
+            status="paused",
+            paused_step_id="approve",
+            workflow=wf,
+            completed_steps=["draft"],
+            state={"input": "hello", "draft_text": "Mock response"},
+            step_results={
+                "draft": {
+                    "step_id": "draft",
+                    "status": "success",
+                    "output": "Mock response",
+                    "duration_ms": 10.0,
+                },
+            },
+        )
+
+        with patch("agentloom.cli.run._setup_providers") as mock_setup:
+            from tests.conftest import MockProvider
+
+            def _wire(gw: object, default: str) -> None:
+                from agentloom.providers.gateway import ProviderGateway
+
+                assert isinstance(gw, ProviderGateway)
+                gw.register(MockProvider(), priority=0)
+
+            mock_setup.side_effect = _wire
+
+            with patch("agentloom.cli.run._setup_observer", return_value=None):
+                result = runner.invoke(
+                    app,
+                    [
+                        "resume",
+                        "approve-ok",
+                        "--checkpoint-dir",
+                        str(tmp_path),
+                        "--lite",
+                        "--approve",
+                    ],
+                )
+
+        assert result.exit_code == 0, f"stdout: {result.output}"
+        assert "decision=approved" in result.output
+
+    def test_resume_reject_flag(self, tmp_path: Path) -> None:
+        wf = _approval_workflow()
+        _write_checkpoint(
+            tmp_path,
+            "reject-ok",
+            status="paused",
+            paused_step_id="approve",
+            workflow=wf,
+            completed_steps=["draft"],
+            state={"input": "hello", "draft_text": "Mock response"},
+            step_results={
+                "draft": {
+                    "step_id": "draft",
+                    "status": "success",
+                    "output": "Mock response",
+                    "duration_ms": 10.0,
+                },
+            },
+        )
+
+        with patch("agentloom.cli.run._setup_providers") as mock_setup:
+            from tests.conftest import MockProvider
+
+            def _wire(gw: object, default: str) -> None:
+                from agentloom.providers.gateway import ProviderGateway
+
+                assert isinstance(gw, ProviderGateway)
+                gw.register(MockProvider(), priority=0)
+
+            mock_setup.side_effect = _wire
+
+            with patch("agentloom.cli.run._setup_observer", return_value=None):
+                result = runner.invoke(
+                    app,
+                    [
+                        "resume",
+                        "reject-ok",
+                        "--checkpoint-dir",
+                        str(tmp_path),
+                        "--lite",
+                        "--reject",
+                    ],
+                )
+
+        assert result.exit_code == 0, f"stdout: {result.output}"
+        assert "decision=rejected" in result.output
+
+    def test_approve_reject_mutual_exclusion(self, tmp_path: Path) -> None:
+        _write_checkpoint(tmp_path, "both-flags", status="paused", paused_step_id="gate")
+
+        result = runner.invoke(
+            app,
+            [
+                "resume",
+                "both-flags",
+                "--checkpoint-dir",
+                str(tmp_path),
+                "--approve",
+                "--reject",
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "Cannot use --approve and --reject together" in (
+            result.output + (result.stderr or "")
+        )

--- a/tests/core/test_engine_approval.py
+++ b/tests/core/test_engine_approval.py
@@ -1,0 +1,243 @@
+"""Tests for the approval gate step integrated with the workflow engine."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agentloom.checkpointing.file import FileCheckpointer
+from agentloom.core.engine import WorkflowEngine
+from agentloom.core.models import (
+    StepDefinition,
+    StepType,
+    WorkflowConfig,
+    WorkflowDefinition,
+)
+from agentloom.core.results import StepStatus, WorkflowStatus
+from agentloom.providers.gateway import ProviderGateway
+from tests.conftest import MockProvider
+
+
+def _mock_gateway(provider: MockProvider | None = None) -> ProviderGateway:
+    gw = ProviderGateway()
+    gw.register(provider or MockProvider(), priority=0)
+    return gw
+
+
+def _approval_workflow() -> WorkflowDefinition:
+    """Linear workflow: draft → approve → send."""
+    return WorkflowDefinition(
+        name="approval-test",
+        config=WorkflowConfig(provider="mock", model="mock-model"),
+        state={"input": "hello"},
+        steps=[
+            StepDefinition(
+                id="draft",
+                type=StepType.LLM_CALL,
+                prompt="Draft: {state.input}",
+                output="draft_text",
+            ),
+            StepDefinition(
+                id="approve",
+                type=StepType.APPROVAL_GATE,
+                depends_on=["draft"],
+                output="decision",
+            ),
+            StepDefinition(
+                id="send",
+                type=StepType.LLM_CALL,
+                depends_on=["approve"],
+                prompt="Send (decision={state.decision}): {state.draft_text}",
+                output="result",
+            ),
+        ],
+    )
+
+
+class TestApprovalGatePause:
+    async def test_approval_gate_pauses_workflow(self) -> None:
+        engine = WorkflowEngine(
+            workflow=_approval_workflow(),
+            provider_gateway=_mock_gateway(),
+        )
+        result = await engine.run()
+
+        assert result.status == WorkflowStatus.PAUSED
+        assert result.step_results["draft"].status == StepStatus.SUCCESS
+        assert result.step_results["approve"].status == StepStatus.PAUSED
+        assert "send" not in result.step_results
+
+    async def test_approval_gate_saves_checkpoint(self, tmp_path: Path) -> None:
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+        engine = WorkflowEngine(
+            workflow=_approval_workflow(),
+            provider_gateway=_mock_gateway(),
+            checkpointer=checkpointer,
+            run_id="approval-ckpt",
+        )
+        await engine.run()
+
+        loaded = await checkpointer.load("approval-ckpt")
+        assert loaded.status == "paused"
+        assert loaded.paused_step_id == "approve"
+        assert "draft" in loaded.completed_steps
+        assert "approve" not in loaded.completed_steps
+
+    async def test_approval_preserves_prior_outputs(self) -> None:
+        engine = WorkflowEngine(
+            workflow=_approval_workflow(),
+            provider_gateway=_mock_gateway(),
+        )
+        result = await engine.run()
+
+        assert "draft_text" in result.final_state
+        assert "decision" not in result.final_state
+
+
+class TestApprovalGateResume:
+    async def test_resume_with_approve(self, tmp_path: Path) -> None:
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+
+        # First run — pauses at approve
+        engine = WorkflowEngine(
+            workflow=_approval_workflow(),
+            provider_gateway=_mock_gateway(),
+            checkpointer=checkpointer,
+            run_id="approve-run",
+        )
+        first = await engine.run()
+        assert first.status == WorkflowStatus.PAUSED
+
+        # Resume with approval
+        checkpoint_data = await checkpointer.load("approve-run")
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=checkpoint_data,
+            checkpointer=checkpointer,
+            provider_gateway=_mock_gateway(),
+            approval_decisions={"approve": "approved"},
+        )
+        second = await resumed.run()
+
+        assert second.status == WorkflowStatus.SUCCESS
+        assert second.step_results["approve"].status == StepStatus.SUCCESS
+        assert second.step_results["approve"].output == "approved"
+        assert second.step_results["send"].status == StepStatus.SUCCESS
+
+    async def test_resume_with_reject(self, tmp_path: Path) -> None:
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+
+        engine = WorkflowEngine(
+            workflow=_approval_workflow(),
+            provider_gateway=_mock_gateway(),
+            checkpointer=checkpointer,
+            run_id="reject-run",
+        )
+        await engine.run()
+
+        checkpoint_data = await checkpointer.load("reject-run")
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=checkpoint_data,
+            checkpointer=checkpointer,
+            provider_gateway=_mock_gateway(),
+            approval_decisions={"approve": "rejected"},
+        )
+        second = await resumed.run()
+
+        assert second.status == WorkflowStatus.SUCCESS
+        assert second.step_results["approve"].output == "rejected"
+        assert second.final_state["decision"] == "rejected"
+
+    async def test_downstream_reads_decision(self, tmp_path: Path) -> None:
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+
+        engine = WorkflowEngine(
+            workflow=_approval_workflow(),
+            provider_gateway=_mock_gateway(),
+            checkpointer=checkpointer,
+            run_id="downstream-run",
+        )
+        await engine.run()
+
+        checkpoint_data = await checkpointer.load("downstream-run")
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=checkpoint_data,
+            checkpointer=checkpointer,
+            provider_gateway=_mock_gateway(),
+            approval_decisions={"approve": "approved"},
+        )
+        second = await resumed.run()
+
+        assert second.final_state["decision"] == "approved"
+        assert "result" in second.final_state
+
+    async def test_resume_skips_completed_steps(self, tmp_path: Path) -> None:
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+
+        engine = WorkflowEngine(
+            workflow=_approval_workflow(),
+            provider_gateway=_mock_gateway(),
+            checkpointer=checkpointer,
+            run_id="skip-run",
+        )
+        await engine.run()
+
+        resume_provider = MockProvider()
+        resume_gw = ProviderGateway()
+        resume_gw.register(resume_provider, priority=0)
+
+        checkpoint_data = await checkpointer.load("skip-run")
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=checkpoint_data,
+            checkpointer=checkpointer,
+            provider_gateway=resume_gw,
+            approval_decisions={"approve": "approved"},
+        )
+        await resumed.run()
+
+        # draft was already done — only send should call the provider
+        assert len(resume_provider.calls) == 1
+
+    async def test_resume_without_decision_pauses_again(self, tmp_path: Path) -> None:
+        """Resuming without --approve/--reject re-pauses at the gate."""
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+
+        engine = WorkflowEngine(
+            workflow=_approval_workflow(),
+            provider_gateway=_mock_gateway(),
+            checkpointer=checkpointer,
+            run_id="no-decision-run",
+        )
+        await engine.run()
+
+        checkpoint_data = await checkpointer.load("no-decision-run")
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=checkpoint_data,
+            checkpointer=checkpointer,
+            provider_gateway=_mock_gateway(),
+        )
+        second = await resumed.run()
+
+        assert second.status == WorkflowStatus.PAUSED
+
+    async def test_final_checkpoint_updated(self, tmp_path: Path) -> None:
+        checkpointer = FileCheckpointer(checkpoint_dir=tmp_path)
+
+        engine = WorkflowEngine(
+            workflow=_approval_workflow(),
+            provider_gateway=_mock_gateway(),
+            checkpointer=checkpointer,
+            run_id="final-ckpt-run",
+        )
+        await engine.run()
+
+        checkpoint_data = await checkpointer.load("final-ckpt-run")
+        resumed = await WorkflowEngine.from_checkpoint(
+            checkpoint_data=checkpoint_data,
+            checkpointer=checkpointer,
+            provider_gateway=_mock_gateway(),
+            approval_decisions={"approve": "approved"},
+        )
+        await resumed.run()
+
+        final = await checkpointer.load("final-ckpt-run")
+        assert final.status == "success"
+        assert final.paused_step_id is None

--- a/tests/steps/test_approval_gate.py
+++ b/tests/steps/test_approval_gate.py
@@ -1,0 +1,82 @@
+"""Tests for the approval gate step executor."""
+
+from __future__ import annotations
+
+import pytest
+
+from agentloom.core.models import StepDefinition, StepType
+from agentloom.core.results import StepStatus
+from agentloom.core.state import StateManager
+from agentloom.exceptions import PauseRequestedError, StepError
+from agentloom.steps.approval_gate import ApprovalGateStep
+from agentloom.steps.base import StepContext
+
+
+def _context(
+    step_id: str = "gate",
+    output: str | None = "decision",
+    state: dict | None = None,
+) -> StepContext:
+    """Build a minimal StepContext for the approval gate."""
+    return StepContext(
+        step_definition=StepDefinition(
+            id=step_id,
+            type=StepType.APPROVAL_GATE,
+            output=output,
+        ),
+        state_manager=StateManager(initial_state=state or {}),
+    )
+
+
+class TestApprovalGateStep:
+    async def test_pauses_without_decision(self) -> None:
+        ctx = _context()
+        with pytest.raises(PauseRequestedError, match="gate"):
+            await ApprovalGateStep().execute(ctx)
+
+    async def test_returns_approved(self) -> None:
+        ctx = _context(state={"_approval": {"gate": "approved"}})
+        result = await ApprovalGateStep().execute(ctx)
+
+        assert result.status == StepStatus.SUCCESS
+        assert result.output == "approved"
+
+    async def test_returns_rejected(self) -> None:
+        ctx = _context(state={"_approval": {"gate": "rejected"}})
+        result = await ApprovalGateStep().execute(ctx)
+
+        assert result.status == StepStatus.SUCCESS
+        assert result.output == "rejected"
+
+    async def test_invalid_decision_raises(self) -> None:
+        ctx = _context(state={"_approval": {"gate": "maybe"}})
+        with pytest.raises(StepError, match="Invalid approval decision"):
+            await ApprovalGateStep().execute(ctx)
+
+    async def test_stores_output_in_state(self) -> None:
+        ctx = _context(output="my_decision", state={"_approval": {"gate": "approved"}})
+        await ApprovalGateStep().execute(ctx)
+
+        value = await ctx.state_manager.get("my_decision")
+        assert value == "approved"
+
+    async def test_no_output_field(self) -> None:
+        """When output is None, the decision is not stored in state."""
+        ctx = _context(output=None, state={"_approval": {"gate": "rejected"}})
+        result = await ApprovalGateStep().execute(ctx)
+
+        assert result.output == "rejected"
+        # No key written to state
+        value = await ctx.state_manager.get("my_decision")
+        assert value is None
+
+    async def test_pause_message_on_stderr(self, capsys: pytest.CaptureFixture[str]) -> None:
+        ctx = _context(step_id="review")
+        with pytest.raises(PauseRequestedError):
+            await ApprovalGateStep().execute(ctx)
+
+        captured = capsys.readouterr()
+        assert "APPROVAL REQUIRED" in captured.err
+        assert "review" in captured.err
+        assert "--approve" in captured.err
+        assert "--reject" in captured.err


### PR DESCRIPTION
## What

Adds the `approval_gate` step type that pauses a workflow until a human approves or rejects. On first execution the step raises `PauseRequestedError`; on resume with `--approve` or `--reject`, the CLI injects the decision into state and the step returns it as output.

New additions:
- `StepType.APPROVAL_GATE` enum value and `ApprovalGateStep` executor
- `timeout_seconds` and `on_timeout` fields on `StepDefinition`
- `approval_decisions` parameter on `WorkflowEngine.from_checkpoint()` — injects decisions into state as `_approval.<step_id>`
- `--approve` / `--reject` mutually exclusive flags on `agentloom resume`
- 16 unit + integration tests (step, engine, CLI)
- Example workflow (29), functional validation script, and K8s smoke job
- External audit script with 55 checks across source contracts, test coverage, and runtime validation

## Why

Part 2 of the HITL milestone. Builds on the pause/resume mechanism from #40 to provide a concrete step type that blocks execution until a human makes a decision. Issue #42 (webhook notifications) will extend this with outbound notifications when a gate pauses.

Closes #41

## Testing

- [x] `uv run pytest` passes (764 tests)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run mypy src/` clean
- [x] `uv run python scripts/validate_approval_gate.py` — functional validation (local)
- [x] Docker: `docker run --rm --entrypoint python3 -v $(pwd)/scripts/validate_approval_gate.py:/tmp/validate.py:ro agentloom:dev /tmp/validate.py`
- [x] Kubernetes: `kubectl apply -f deploy/k8s/examples/approval-gate-job.yaml` — Kind smoke test passed

## Notes

- The step uses `_approval.<step_id>` as a state convention — the underscore prefix signals internal/framework keys.
- `--approve` and `--reject` are mutually exclusive; the decision is mapped to the `paused_step_id` from the checkpoint.
- The K8s pause-resume job had a stale python path (`/build/.venv/bin/python` → `python3`) — fixed in this PR.