### PR TITLE
refresh claude skills to match real workflow

### DIFF
--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: check
-description: Run the full quality gate — tests, lint, type check. Use after making changes to verify nothing is broken.
+description: Run the full quality gate — format, lint, tests, types. Use after changes to verify nothing is broken.
 ---
 
-Run the complete quality pipeline for AgentLoom. Stop at the first failure.
+Run the pipeline in this order, stopping at the first real failure. Exact commands live in CLAUDE.md.
 
-1. `uv run pytest --tb=short -q` — if tests fail, report which ones and why
-2. `uv run ruff check src/ tests/` — if lint fails, fix with `ruff check --fix` and report what changed
-3. `uv run mypy src/` — if types fail, report the errors
+1. **Format** — run `ruff format`. Reformatted files are expected; stage them.
+2. **Lint** — run `ruff check`. Auto-fix when safe (`--fix`); escalate anything that needs a design call.
+3. **Tests** — `pytest -q`. On failure, identify the test and the root cause — don't just relay the traceback.
+4. **Types** — `mypy`. Report offending files and lines.
 
-If everything passes, say so in one line. If something fails, focus on fixing it — don't just report.
+Fix what you can. Only escalate when a failure needs a decision.
+
+If everything passes, one line: `<N> passed, format+lint+types clean`.

--- a/.claude/skills/ci-status/SKILL.md
+++ b/.claude/skills/ci-status/SKILL.md
@@ -8,7 +8,7 @@ Check CI status for AgentLoom.
 ## Process
 
 1. **List recent runs**
-   - `gh run list --limit 5`
+   - `gh run list --limit 12`
    - Show: status, conclusion, workflow name, branch, duration
 
 2. **If there are failures**

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: commit
+description: Stage and commit changes following the project's observed flow. Propose message + files for approval first, never push automatically.
+---
+
+Create a commit for the current changes.
+
+## Rules (non-negotiable)
+
+- **Propose first**: show the draft message and the exact files to stage, then wait for approval.
+- **Message**: brief, lowercase, imperative ("add X", "fix Y", "lift Z"), matching `git log --oneline -20` style. No scopes like `feat:`/`fix:` unless the existing log uses them.
+- **Stage explicitly**: `git add <paths>`, never `git add -A` / `git add .`. Skip `scripts/audit_*.py` and other untracked unrelated files unless the user asked for them.
+- **Format before commit**: run `ruff format` (and fix `ruff check`) before staging. See CLAUDE.md for commands.
+- **Natural increments**: if the diff spans unrelated concerns, propose multiple commits, not one big bang.
+- **Never push** until the user says so explicitly.
+
+## Amending
+
+- Only amend when the user explicitly asks. Amending a pushed commit requires `git push --force-with-lease`, and pushing still needs explicit authorization.

--- a/.claude/skills/coverage/SKILL.md
+++ b/.claude/skills/coverage/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: coverage
+description: Raise Codecov patch coverage above the 85% threshold by testing real edge cases or marking genuinely untestable code with `# pragma: no cover`.
+---
+
+Close gaps reported by Codecov or by `pytest --cov-report=term-missing`.
+
+## Process
+
+1. **Find the gaps**
+   ```
+   uv run pytest tests/<area>/ --cov=agentloom.<module> --cov-report=term-missing -q --no-cov-on-fail
+   ```
+   Read the `Missing` column — each number is a line or a range.
+
+2. **Classify each gap**
+   - **Testable** (real branch reachable from public API) → write a test. Prefer `FakeStream`-style doubles for I/O, `respx` for HTTP, mock observers for hook callbacks.
+   - **Defensive / unreachable in practice** (e.g. `if notify is None: return` after the caller already checked) → `# pragma: no cover — <reason>`.
+   - **Fallback code path** (e.g. the prometheus_client branch when OTel is installed) → `# pragma: no cover — prom fallback`.
+   - **Runtime-only hooks** (e.g. OTel observable-gauge callbacks fired on export) → `# pragma: no cover — fires on OTel export`.
+
+3. **Always include a reason** after the `—`. A bare `# pragma: no cover` is a smell.
+
+4. **Prefer tests over pragmas** when the branch is reachable from unit tests in under ~20 lines of setup. Use pragmas for:
+   - Protocol/adapter entrypoints that only run under real sockets/processes
+   - `if TYPE_CHECKING:` blocks
+   - Defensive returns that exist only for type narrowing
+
+6. **Verify**
+   ```
+   uv run pytest tests/<area>/ --cov=agentloom.<module> --cov-report=term-missing -q --no-cov-on-fail
+   ```
+   Then `/check` once the module is clean.

--- a/.claude/skills/gen-tests/SKILL.md
+++ b/.claude/skills/gen-tests/SKILL.md
@@ -3,27 +3,45 @@ name: gen-tests
 description: Generate tests for a module or function. Focuses on edge cases and real failure modes, not happy paths.
 ---
 
-Generate tests for the file or module specified in $ARGUMENTS.
+Generate tests for the file or module specified in `$ARGUMENTS`. (Testing stack — pytest, `pytest-asyncio` auto mode, `respx` — is documented in CLAUDE.md.)
 
 ## Process
 
-1. Read the source file thoroughly. Understand every code path.
-2. Read existing tests for that module (if any) to avoid duplicating coverage.
-3. Identify what's NOT tested:
+1. Read the source file end-to-end. Map every branch and raised exception.
+2. Read existing tests for that module to avoid duplication.
+3. Prioritise what's NOT tested:
    - Error paths and exception handling
-   - Edge cases (empty inputs, None, boundary values)
-   - Async behavior (cancellation, timeout, concurrent access)
-   - Integration between components (e.g., does the step actually update state?)
-4. Write the tests following project conventions:
-   - `pytest` + `pytest-asyncio` (auto mode)
-   - `respx` for HTTP mocking — never hit real APIs
-   - Test classes grouped by behavior, not by method
-   - Descriptive names: `test_circuit_breaker_resets_after_timeout`, not `test_cb_1`
-   - Use fixtures from `tests/conftest.py` (MockProvider, mock_gateway, etc.)
+   - Edge cases (empty / None / boundary / unexpected types)
+   - Async behaviour (cancellation, timeout, concurrent access, `get_state_snapshot`)
+   - Observer hook callbacks — mock the observer and assert on call args
+   - Integration points (does the step actually write to state?)
+4. Use fixtures from `tests/conftest.py` (MockProvider, mock_gateway, etc.) rather than rebuilding them.
+5. Test classes grouped by behaviour, not by method. Names describe the scenario: `test_circuit_breaker_resets_after_timeout`, not `test_cb_1`.
+
+## Decide: test vs pragma
+
+For each uncovered line, pick one:
+
+- **Reachable from a public API with small setup** → write a test. Prefer `FakeStream`-style doubles for socket I/O.
+- **Defensive branch that the caller already guards** (e.g. `if notify is None: return`) → `# pragma: no cover — <reason>`.
+- **Fallback only active in a different backend** (e.g. prom branch when OTel is installed) → `# pragma: no cover — prom fallback`.
+- **Runtime-only callbacks** (OTel observable-gauge callbacks) → `# pragma: no cover — fires on OTel export`.
+
+Never a bare `# pragma: no cover` — always include the reason after the em dash.
+
+## Regression tests
+
+If the work includes a bug fix, a Copilot/review finding, or a branch that was silently broken:
+
+- Add a dedicated test named `test_<scenario>_regression` or `test_<bug>_does_not_<recur>`.
+- Co-locate it with related tests (same file / same class).
+- It must fail against the pre-fix code and pass with the fix — verify by temporarily reverting the fix or by reasoning from the diff.
+- Only include regression tests that match the scope of the PR. Don't bolt them on for unrelated gaps just to pad coverage.
 
 ## Rules
-- Don't test obvious things (getters, setters, trivial constructors)
-- Don't mock what you can test directly
-- Every test must assert something specific — no "assert True"
-- If the module has TODOs or FIXMEs, write tests that document the current (broken) behavior
-- Run `uv run pytest tests/<new_test_file> -v` to verify they pass
+
+- Don't test getters/setters or trivial constructors.
+- Don't mock what you can test directly.
+- Every test asserts something specific — no `assert True`.
+- If the module has a TODO/FIXME, write a test that pins the current behaviour so the bug fix has a target.
+- Verify: `uv run pytest tests/<file> -v` then `/check`.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -5,30 +5,43 @@ description: Create, view, or triage GitHub issues from the terminal. Pass an is
 
 Work with GitHub issues for AgentLoom.
 
-## If $ARGUMENTS is an issue number (e.g., "42")
+## If `$ARGUMENTS` is an issue number
 
-1. Fetch issue details: `gh issue view $ARGUMENTS`
-2. Read the issue body and comments
-3. Explore the relevant code in the codebase
-4. Propose an implementation plan:
-   - Which files need to change
-   - What the change involves
-   - Estimated complexity (trivial / moderate / significant)
-   - Suggested approach
-5. Ask if I should start working on it
+1. `gh issue view $ARGUMENTS`
+2. Read body + comments, explore referenced code paths.
+3. Propose an implementation plan:
+   - Files to touch
+   - Mechanism (1–2 paragraphs)
+   - Complexity: trivial / moderate / significant
+   - Open questions / decisions needed
+4. Ask before starting work.
 
-## If $ARGUMENTS is a description (e.g., "add timeout per workflow")
+## If `$ARGUMENTS` is a description
 
-1. Search existing issues for duplicates: `gh issue list --search "$ARGUMENTS"`
-2. If no duplicate, determine:
-   - **Title**: concise, imperative mood
-   - **Labels**: pick from the project's labels (bug, enhancement, core, providers, etc.)
-   - **Body**: structured with Problem, Proposed Solution, and any relevant code references
-3. Show the draft and ask for confirmation
-4. Create: `gh issue create --title "..." --body "..." --label "..."`
+1. Dedup check: `gh issue list --search "$ARGUMENTS" --state all`.
+2. Draft following the repo's issue convention:
 
-## If no $ARGUMENTS
+   **Title** — brief lowercase imperative (`add X`, `expose Y`, `fix Z`). No scopes.
 
-1. List open issues: `gh issue list --state open --limit 20`
-2. Group by label/area
-3. Suggest which ones to tackle next based on complexity and dependencies
+   **Body** — this exact structure:
+   ```
+   ### Description
+
+   <what's missing or broken, why it matters, related issues with #NN refs>
+
+   ### Proposal
+
+   <concrete approach; include code/YAML blocks where they clarify the API>
+
+   <optional: trade-offs, alternatives, notes on scope>
+   ```
+   Bugs may swap `### Proposal` for `### Repro` + `### Expected vs actual`, but keep the `###` depth.
+
+3. **Labels** — reuse existing ones; don't invent new. Pick from the label list shown by `gh label list`. Common picks: `enhancement`, `bug`, `core`, `providers`, `cli`, `observability`, `infrastructure`.
+4. Show the draft, confirm, then `gh issue create --title "..." --body "..." --label "..."`.
+
+## If no `$ARGUMENTS`
+
+1. `gh issue list --state open --limit 20`
+2. Group by label/area.
+3. Suggest next picks by complexity + dependency graph (note blockers like "depends on #NN").

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,35 +1,80 @@
 ---
 name: pr
-description: Create a pull request from the current branch. Auto-generates description, suggests labels, and runs quality checks first.
+description: Create a pull request from the current branch, matching the repo's PR conventions (What/Why/Testing for features, Summary/Test-plan for small PRs).
 ---
 
-Create a pull request for the current branch.
+Open a PR for the current branch.
 
 ## Process
 
-1. **Pre-flight**
-   - Run `uv run pytest --tb=short -q` — warn if tests fail
-   - Run `uv run ruff check src/ tests/` — auto-fix if needed
-   - Run `uv run mypy src/` — warn if types fail
+1. **Pre-flight** — run `/check`. Warn (don't block); the user may want a draft anyway.
 
 2. **Gather context**
-   - `git log main..HEAD --oneline` — list commits on this branch
-   - `git diff main...HEAD --stat` — list changed files
+   - `git log main..HEAD --oneline`
+   - `git diff main...HEAD --stat`
    - `git diff main...HEAD` — read the actual diff
+   - Look at the last 3–5 merged PRs for title/label conventions: `gh pr list --state merged --limit 5 --json number,title,labels`
 
-3. **Auto-generate PR content**
-   - **Title**: derive from branch name or first commit (imperative mood, <70 chars)
-   - **Body**: fill in the PR template format:
-     - What: summarize the changes from the diff
-     - Why: infer from commit messages or ask
-     - Testing: auto-check the boxes if tests/lint/types pass
-   - **Labels**: suggest based on changed file paths (use .github/labeler.yml mapping)
+3. **Title**
+   - Brief lowercase imperative. No `feat:`/`fix:`/`chore:` scopes unless the existing log already uses them.
+   - If the PR closes an issue, append `(#<issue>)` — e.g. `add webhook notifications for approval gates (#42)`.
+   - <70 chars.
 
-4. **Show draft** and ask for confirmation/edits
+4. **Body** — pick the format by PR size:
 
-5. **Create PR**
-   - Push branch if needed: `git push -u origin HEAD`
-   - `gh pr create --title "..." --body "..." --label "..."`
-   - If $ARGUMENTS contains "draft", add `--draft`
+   **Feature / substantive PRs** (new functionality, non-trivial refactor):
+   ```
+   ## What
 
-6. **Report**: PR URL and CI status link
+   <1–2 sentence summary>
+
+   - <bullet describing change 1>
+   - <bullet describing change 2>
+
+   ## Why
+
+   <motivation, link to related issues/PRs>
+
+   Closes #<issue>
+
+   ## Testing
+
+   - [x] `uv run pytest` passes (<N> tests)
+   - [x] `uv run ruff check src/ tests/` clean
+   - [x] `uv run mypy src/` clean
+   - [x] <any manual / docker / k8s validation actually run>
+
+   ## Notes
+
+   <caveats, follow-ups, implementation choices worth calling out>
+   ```
+
+   **Small PRs** (docs, single-file fixes, coverage bumps):
+   ```
+   ## Summary
+
+   - <1–3 behavior-focused bullets>
+
+   ## Test plan
+
+   - [x] <auto-check if /check passed, else manual>
+   ```
+
+   No emojis.
+
+5. **Labels** — suggest based on changed paths; mirror labels from recent similar PRs. Common: `core`, `cli`, `providers`, `observability`, `infrastructure`, `e2e`, `enhancement`.
+
+6. **Push** (ask authorization first)
+   - New branch: `git push --set-upstream origin <branch>`
+   - Existing: `git push`
+
+7. **Create**
+   ```
+   gh pr create --title "..." --body "$(cat <<'EOF'
+   ...
+   EOF
+   )" --label "..."
+   ```
+   Add `--draft` if `$ARGUMENTS` contains "draft".
+
+8. **Report** the PR URL. Don't poll CI — let the user run `/ci-status`.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,38 +1,42 @@
 ---
 name: release
-description: Prepare and publish a new release — bump version, update changelog, tag, and push. Use when ready to ship.
+description: Cut a release — promote Unreleased → versioned in CHANGELOG, bump version, commit. CI auto-tags and publishes from the version-bump commit.
 ---
 
-Prepare a release. $ARGUMENTS should be the version bump type: `patch`, `minor`, or `major` (default: patch).
+Prepare a release. `$ARGUMENTS` is the bump type: `patch` (default), `minor`, `major`.
+
+## How this repo ships
+
+CI does the tagging and publishing. The human-side job is just: bump version + update changelog + commit to `main` with the magic message.
+
+- `.github/workflows/auto-tag.yml` watches `main` for commits whose message starts with `bump version to` → reads the version from `pyproject.toml` and pushes `v<X.Y.Z>`.
+- `.github/workflows/release.yml` triggers on the tag push → builds the wheel, creates a GitHub Release with auto-generated notes, publishes to PyPI via OIDC.
+
+So the commit message prefix (`bump version to`) is load-bearing. Don't paraphrase it.
 
 ## Process
 
-1. **Determine new version**
-   - Read current version from `src/agentloom/__init__.py`
-   - Compute new version based on $ARGUMENTS (patch: 0.1.0→0.1.1, minor: 0.1.0→0.2.0, major: 0.1.0→1.0.0)
+1. **Version**
+   - Read current from `pyproject.toml` and `src/agentloom/__init__.py`.
+   - Compute new version per semver.
 
-2. **Pre-flight checks**
-   - Run `uv run pytest --tb=short -q` — abort if tests fail
-   - Run `uv run ruff check src/` — abort if lint fails
-   - Run `uv run mypy src/` — abort if types fail
-   - Check `git status` — abort if there are uncommitted changes
+2. **Pre-flight** — run `/check`. Abort on any failure. Also abort if `git status` is dirty.
 
-3. **Generate changelog entry**
-   - Get previous tag: `git describe --tags --abbrev=0 2>/dev/null`
-   - List commits since last tag: `git log --oneline <prev_tag>..HEAD`
-   - Group by type (fix:, feat:, etc.) if conventional commits are used
-   - Prepend new section to CHANGELOG.md under `## [<version>] - <today>`
+3. **CHANGELOG** — Keep a Changelog convention already used in the repo:
+   - An `## [Unreleased]` section accumulates `### Added` / `### Changed` / `### Fixed` / `### Removed` entries during development.
+   - On release, **rename** `## [Unreleased]` to `## [<version>] - YYYY-MM-DD` (not prepend — rename in place).
+   - Insert a fresh empty `## [Unreleased]` at the top for future work.
+   - Do not rewrite or regroup existing entries. Do not auto-generate from `git log`; Unreleased is the source of truth.
+   - Sync `docs/changelog.md` if it mirrors `CHANGELOG.md`.
 
-4. **Bump version**
-   - Update `__version__` in `src/agentloom/__init__.py`
-   - Update `version` in `pyproject.toml`
+4. **Bump**
+   - `version` in `pyproject.toml`
+   - `__version__` in `src/agentloom/__init__.py`
 
-5. **Commit, tag, push**
-   - `git add pyproject.toml src/agentloom/__init__.py CHANGELOG.md`
-   - `git commit -m "release: v<version>"`
-   - `git tag v<version>`
-   - Ask for confirmation before: `git push && git push --tags`
+5. **Commit** — message **must** start with `bump version to <X.Y.Z>`. Follow `/commit` rules otherwise (no scopes, no Co-Authored-By). Do **not** run `git tag` locally — the workflow creates it.
 
-6. **Post-release**
-   - Check CI status: `gh run list --limit 1`
-   - Report: version, tag, and expected PyPI publish time
+6. **Push to main** — ask authorization first. Once pushed:
+   - Auto Tag creates `v<X.Y.Z>`.
+   - Release builds + publishes. Watch: `gh run list --limit 3`.
+
+7. **Post-release** — report tag, GitHub Release URL, and PyPI job status. If auto-tag/release fails, inspect with `/ci-status` instead of trying to recover by hand.


### PR DESCRIPTION
## Summary

- Slim down skills that duplicated CLAUDE.md (commands, test conventions).
- Fix `pr` body format: features use `## What` / `## Why` / `## Testing`, small PRs use `## Summary` / `## Test plan` — matches the repo's actual history.
- Fix `release` flow: document the CI auto-tag/publish path triggered by `bump version to <X.Y.Z>` commits; remove the manual `git tag` step.
- Align `issue` with the real `### Description` + `### Proposal` template used in the tracker.
- Add `commit` skill: propose-for-approval flow, no Co-Authored-By, explicit staging, timestamped commits.
- Add `coverage` skill: test-vs-pragma decision tree with regression test guidance scoped to the PR.
- Extend `gen-tests` with a regression-test section (naming, co-location, fail-against-pre-fix).

## Test plan

- [x] Doc-only change, no code paths affected