### PR TITLE
add mock and recording providers for deterministic replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ deploy/terraform/agentloom-dev-config
 site/
 .agentloom/checkpoints/*
 !.agentloom/checkpoints/.gitkeep
+
+recordings/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Production `MockProvider` and `RecordingProvider` for deterministic replay and offline evaluation (#76)
+  - `MockProvider` loads responses from a JSON file, keyed by `step_id` or SHA-256 prompt hash
+  - Latency models: `constant`, `normal` (gaussian with seed), `replay` (uses recorded `latency_ms`)
+  - `RecordingProvider` wraps any provider, captures completions to JSON, flushes per-call
+  - `agentloom run --mock-responses <file>` replays; `--record <file>` captures
 - Webhook notifications for approval gates — outbound HTTP on pause (#42)
   - `WebhookConfig` on `StepDefinition.notify` with URL, custom headers, and body template
   - Async webhook sender with 3-retry exponential backoff (best-effort, never blocks pause)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@
 - [Observability](#observability)
 - [Deploy](#deploy)
 - [Checkpointing](#checkpointing)
+- [Testing & Replay](#testing--replay)
 - [Why not autonomous agents?](#why-not-autonomous-agents)
 - [Development](#development)
 - [Contributing](#contributing)
@@ -53,6 +54,7 @@ Existing frameworks (LangGraph, CrewAI, AutoGen) treat observability and resilie
 | Cost tracking | No | No | No | **Native with budgets** |
 | Multi-provider fallback | Manual | No | No | **Automatic** |
 | Checkpoint & resume | No | No | No | **Built-in** |
+| Deterministic replay | No | No | No | **Built-in (record + mock)** |
 | Dependencies | Heavy | Medium | Medium | **Minimal** |
 
 ## Quick Start
@@ -360,6 +362,20 @@ agentloom resume <run_id>
 ```
 
 Checkpoints are stored as JSON files in `.agentloom/checkpoints/` by default. The backend is pluggable — implement `BaseCheckpointer` to store checkpoints in Redis, S3, or any other backend. In Kubernetes, mount a PersistentVolumeClaim to share checkpoints across Jobs.
+
+## Testing & Replay
+
+Record real LLM responses once, replay them offline forever — reproducible tests, CI without API keys, statistical evaluation without paying per-run.
+
+```bash
+# Capture a real run to disk (flushes per call; crashes leave partial recordings)
+agentloom run workflow.yaml --record recordings/run1.json
+
+# Replay offline — no network, no key, no cost, byte-identical output
+agentloom run workflow.yaml --mock-responses recordings/run1.json
+```
+
+Responses are keyed by `step_id` or a SHA-256 hash of the messages. `MockProvider` supports three latency models (`constant`, `normal`, `replay`) for faithful performance reproduction. Replays emit Prometheus metrics (`agentloom_mock_replays_total`, `agentloom_recording_captures_total`) and a dedicated "Mock & Replay" row in the stock Grafana dashboard. See [docs/testing-and-replay](https://cchinchilla-dev.github.io/agentloom/testing-and-replay/) and [`examples/31_record_and_replay.yaml`](examples/31_record_and_replay.yaml).
 
 ## Why not autonomous agents?
 

--- a/deploy/grafana/dashboards/agentloom.json
+++ b/deploy/grafana/dashboards/agentloom.json
@@ -2401,6 +2401,101 @@
     },
     {
       "type": "row",
+      "title": "Mock & Replay",
+      "collapsed": true,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 94},
+      "id": 80,
+      "panels": [
+        {
+          "type": "stat",
+          "title": "Mock Replays",
+          "description": "MockProvider lookups, by how the response was matched",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "id": 81,
+          "gridPos": {"h": 8, "w": 6, "x": 0, "y": 95},
+          "targets": [
+            {
+              "expr": "sum by (matched_by)(agentloom_mock_replays_total)",
+              "legendFormat": "{{matched_by}}",
+              "refId": "A",
+              "instant": true
+            }
+          ],
+          "options": {
+            "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false},
+            "textMode": "value_and_name",
+            "colorMode": "value"
+          }
+        },
+        {
+          "type": "stat",
+          "title": "Replay Hit Ratio",
+          "description": "Fraction of mock lookups that found a recorded response (not the default)",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "id": 82,
+          "gridPos": {"h": 8, "w": 6, "x": 6, "y": 95},
+          "fieldConfig": {
+            "defaults": {"unit": "percentunit", "min": 0, "max": 1},
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "(sum(agentloom_mock_replays_total{matched_by!=\"default\"}) or vector(0)) / (sum(agentloom_mock_replays_total) or vector(1))",
+              "legendFormat": "hit ratio",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Recording Captures by Provider",
+          "description": "Real provider responses captured by RecordingProvider",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "id": 83,
+          "gridPos": {"h": 8, "w": 6, "x": 12, "y": 95},
+          "fieldConfig": {
+            "defaults": {
+              "color": {"mode": "palette-classic"},
+              "custom": {"drawStyle": "line", "fillOpacity": 10}
+            },
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "sum by (provider)(rate(agentloom_recording_captures_total[5m]))",
+              "legendFormat": "{{provider}}",
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "type": "timeseries",
+          "title": "Captured Real-Provider Latency (p50 / p95)",
+          "description": "Latency of the real provider calls that RecordingProvider captured — what replay will simulate with latency_model=replay",
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "id": 84,
+          "gridPos": {"h": 8, "w": 6, "x": 18, "y": 95},
+          "fieldConfig": {
+            "defaults": {"unit": "s"},
+            "overrides": []
+          },
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.5, sum(rate(agentloom_recording_latency_seconds_bucket[5m])) by (le, provider))",
+              "legendFormat": "p50 {{provider}}",
+              "refId": "A"
+            },
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(agentloom_recording_latency_seconds_bucket[5m])) by (le, provider))",
+              "legendFormat": "p95 {{provider}}",
+              "refId": "B"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "row",
       "title": "Streaming",
       "collapsed": true,
       "gridPos": {

--- a/deploy/k8s/examples/mock-provider-job.yaml
+++ b/deploy/k8s/examples/mock-provider-job.yaml
@@ -1,0 +1,137 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mock-provider-script
+  namespace: agentloom
+data:
+  validate_mock_provider.py: |
+    """Functional validation of MockProvider + RecordingProvider in Kubernetes."""
+
+    import json
+    import tempfile
+    from pathlib import Path
+
+    import anyio
+
+    from agentloom.core.engine import WorkflowEngine
+    from agentloom.core.models import (
+        StepDefinition,
+        StepType,
+        WorkflowConfig,
+        WorkflowDefinition,
+    )
+    from agentloom.core.results import TokenUsage, WorkflowStatus
+    from agentloom.providers.base import BaseProvider, ProviderResponse
+    from agentloom.providers.gateway import ProviderGateway
+    from agentloom.providers.mock import MockProvider
+    from agentloom.providers.recorder import RecordingProvider
+
+    class DeterministicProvider(BaseProvider):
+        name = "det"
+        async def complete(self, messages, model, **kwargs):
+            last = messages[-1].get("content", "")
+            return ProviderResponse(
+                content=f"det::{last}", model=model, provider="det",
+                usage=TokenUsage(prompt_tokens=5, completion_tokens=7, total_tokens=12),
+                cost_usd=0.0001, finish_reason="stop",
+            )
+        def supports_model(self, model):
+            return True
+
+    def _wf(provider_name):
+        return WorkflowDefinition(
+            name="mock-k8s",
+            config=WorkflowConfig(provider=provider_name, model="test-model"),
+            state={"question": "what is 2+2"},
+            steps=[
+                StepDefinition(id="draft", type=StepType.LLM_CALL,
+                               prompt="Draft: {state.question}", output="draft_text"),
+                StepDefinition(id="polish", type=StepType.LLM_CALL,
+                               depends_on=["draft"],
+                               prompt="Polish: {state.draft_text}", output="polished"),
+            ],
+        )
+
+    async def main():
+        with tempfile.TemporaryDirectory() as td:
+            recording = Path(td) / "recording.json"
+
+            print("[1/3] Recording from DeterministicProvider...")
+            gw = ProviderGateway()
+            gw.register(RecordingProvider(DeterministicProvider(), recording), priority=0)
+            r = await WorkflowEngine(workflow=_wf("det"), provider_gateway=gw).run()
+            await gw.close()
+            assert r.status == WorkflowStatus.SUCCESS, r.status
+            data = json.loads(recording.read_text())
+            assert len(data) == 2, data
+            draft_out = r.final_state["draft_text"]
+            polished_out = r.final_state["polished"]
+            print(f"  OK: recorded 2 entries ({r.total_tokens} tokens)")
+
+            print("[2/3] Replaying via MockProvider...")
+            gw2 = ProviderGateway()
+            gw2.register(MockProvider(responses_file=recording), priority=0)
+            r2 = await WorkflowEngine(workflow=_wf("mock"), provider_gateway=gw2).run()
+            await gw2.close()
+            assert r2.status == WorkflowStatus.SUCCESS, r2.status
+            assert r2.final_state["draft_text"] == draft_out
+            assert r2.final_state["polished"] == polished_out
+            assert r2.total_tokens == r.total_tokens
+            print(f"  OK: outputs + tokens match (tokens={r2.total_tokens})")
+
+            print("[3/3] Verifying default_response on miss...")
+            mock = MockProvider(responses_file=recording, default_response="FALLBACK")
+            resp = await mock.complete(
+                messages=[{"role": "user", "content": "unseen"}], model="test-model",
+            )
+            assert resp.content == "FALLBACK"
+            print("  OK: unknown prompt -> default_response")
+
+        print("\nAll K8s MockProvider validations passed!")
+
+    anyio.run(main)
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mock-provider-smoke
+  namespace: agentloom
+spec:
+  backoffLimit: 0
+  ttlSecondsAfterFinished: 600
+  activeDeadlineSeconds: 120
+  template:
+    spec:
+      serviceAccountName: agentloom
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: runner
+          image: agentloom:dev
+          imagePullPolicy: Never
+          command: ["/build/.venv/bin/python3"]
+          args: ["/scripts/validate_mock_provider.py"]
+          env:
+            - name: UV_CACHE_DIR
+              value: /tmp/.uv-cache
+          resources:
+            requests:
+              memory: 64Mi
+              cpu: 50m
+            limits:
+              memory: 128Mi
+          securityContext:
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          volumeMounts:
+            - name: script
+              mountPath: /scripts
+              readOnly: true
+      volumes:
+        - name: script
+          configMap:
+            name: mock-provider-script

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,16 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Added
 
+- **Deterministic replay with `MockProvider` and `RecordingProvider`** — offline evaluation and reproducible tests (#76)
+    - `MockProvider` loads pre-recorded responses from a JSON file, keyed by `step_id` or SHA-256 hash of the messages
+    - Latency models: `constant`, `normal` (seeded gaussian), `replay` (uses the recorded `latency_ms`)
+    - `RecordingProvider` wraps any real provider, captures every completion to JSON, flushes per call so a crash still leaves a partial recording
+    - Merge-on-flush: multiple `RecordingProvider` instances writing to the same path accumulate instead of clobbering each other
+    - CLI flags: `agentloom run --record <file>` captures, `--mock-responses <file>` replays — fully offline, zero network
+    - Prometheus metrics: `agentloom_mock_replays_total{workflow, matched_by}`, `agentloom_recording_captures_total{provider, model}`, `agentloom_recording_latency_seconds`
+    - OTel span attributes: `mock.matched_by`, `recording.provider`, `recording.latency_s`
+    - Grafana dashboard row "Mock & Replay" with hit-ratio, captures by provider, and real-provider latency quantiles
+    - Validated end-to-end with real Anthropic calls in CLI, Docker, and Kubernetes (byte-identical replay)
 - **Webhook notifications for approval gates** — outbound HTTP on pause (#42)
     - `WebhookConfig` on `StepDefinition.notify` with URL, custom headers, and JSON body template
     - Async webhook sender with 3-retry exponential backoff (best-effort, never blocks pause)

--- a/docs/testing-and-replay.md
+++ b/docs/testing-and-replay.md
@@ -1,0 +1,157 @@
+# Testing & Replay
+
+AgentLoom ships two providers designed for **offline, deterministic** execution of workflows: `RecordingProvider` captures real LLM responses to disk, and `MockProvider` replays them. Together they enable reproducible tests, CI without API keys, and statistical evaluation without paying per-run.
+
+## When to use which
+
+| Goal | Use |
+|---|---|
+| Reproducible unit/integration tests | `MockProvider` with a committed JSON fixture |
+| CI runs without API keys / network | `MockProvider` |
+| Capturing a real run to replay later | `RecordingProvider` wrapping the real provider |
+| Statistical eval over a fixed response set | `MockProvider` with `latency_model: replay` |
+| Debugging a production incident offline | Record in prod → replay locally |
+
+## Recording a run
+
+Wrap any real provider and capture every completion to a JSON file:
+
+```bash
+agentloom run workflow.yaml --record recordings/run1.json
+```
+
+The file is flushed **per call**, so a crashed workflow still leaves a partial recording. Re-running against the same path accumulates entries — it never clobbers.
+
+The captured format is directly loadable by `MockProvider`:
+
+```json
+{
+  "summarize": {
+    "content": "The article argues that...",
+    "model": "claude-sonnet-4-20250514",
+    "usage": {"prompt_tokens": 412, "completion_tokens": 88, "total_tokens": 500},
+    "cost_usd": 0.00264,
+    "latency_ms": 1843.2,
+    "finish_reason": "stop"
+  }
+}
+```
+
+Keys are the step's `step_id` when available, or the SHA-256 hash of the serialized messages otherwise.
+
+## Replaying a run
+
+Point the CLI at a recorded file:
+
+```bash
+agentloom run workflow.yaml --mock-responses recordings/run1.json
+```
+
+Every `llm_call` step resolves from the JSON. No network, no API key, no cost. Latency is simulated according to `latency_model`.
+
+## Latency models
+
+`MockProvider` supports three modes:
+
+| Model | Behavior | Use case |
+|---|---|---|
+| `constant` (default) | Sleeps `latency_ms` on every call | Fast tests |
+| `normal` | Gaussian around `latency_ms` with σ = 10%, seedable via `seed=` | Jitter simulation |
+| `replay` | Uses the recorded `latency_ms` from the fixture | Faithful reproduction for perf eval |
+
+```python
+from agentloom.providers.mock import MockProvider
+
+mock = MockProvider(
+    responses_file="recordings/run1.json",
+    latency_model="replay",
+)
+```
+
+## Key resolution
+
+`MockProvider` resolves each call in this order:
+
+1. **`step_id` match** — if the caller passes `step_id=` and that key exists in the fixture
+2. **Prompt hash match** — SHA-256 of the serialized messages list
+3. **Default response** — returns `default_response` (defaults to `"Mock response"`) with zero cost/usage
+
+Call metadata is recorded on `provider.calls` and exposed via observer hooks (see [Observability](#observability)).
+
+## Programmatic use
+
+```python
+from agentloom.providers.mock import MockProvider
+from agentloom.providers.recorder import RecordingProvider
+from agentloom.providers.anthropic import AnthropicProvider
+
+# Record
+real = AnthropicProvider(api_key=...)
+recorder = RecordingProvider(real, output_path="fixture.json")
+# ... use recorder like any provider ...
+await recorder.close()  # flushes
+
+# Replay
+mock = MockProvider(responses_file="fixture.json", latency_model="replay")
+```
+
+## Testing patterns
+
+### Pattern 1 — committed fixtures
+
+Commit a JSON fixture under `tests/fixtures/` and use `MockProvider` directly:
+
+```python
+async def test_summarization_workflow():
+    provider = MockProvider(responses_file="tests/fixtures/summary.json")
+    gateway = ProviderGateway()
+    gateway.register(provider)
+    engine = WorkflowEngine(gateway=gateway)
+    result = await engine.run(workflow)
+    assert result.state["summary"] == "expected output"
+```
+
+### Pattern 2 — record once, replay forever
+
+Run the workflow against a real provider once with `--record`, then commit the JSON and switch CI to `--mock-responses`. Re-record when prompts change.
+
+### Pattern 3 — statistical evaluation
+
+Record N variations of a prompt against a real provider, then run your evaluator against the fixture in a tight loop — no rate limits, no cost, deterministic scoring.
+
+## Observability
+
+Both providers emit observer events that bridge to Prometheus and OTel when the `[observability]` extra is installed:
+
+| Metric | Labels | Meaning |
+|---|---|---|
+| `agentloom_mock_replays_total` | `workflow`, `matched_by` (`step_id` / `prompt_hash` / `default`) | Replay hit counter |
+| `agentloom_recording_captures_total` | `provider`, `model` | Captured call counter |
+| `agentloom_recording_latency_seconds` | `provider`, `model` | Histogram of real-provider latency while recording |
+
+OTel span attributes: `mock.matched_by`, `mock.step_id`, `recording.provider`, `recording.model`, `recording.latency_s`.
+
+The stock Grafana dashboard includes a **Mock & Replay** row with:
+
+- Total replays (stat)
+- Hit ratio (`step_id` + `prompt_hash`) vs defaults
+- Captures by provider
+- Captured real-provider latency p50 / p95
+
+## Concurrency & merge semantics
+
+If a workflow registers multiple providers each wrapped with `RecordingProvider` pointing to the same file (e.g. primary + fallback via the gateway), `_flush()` **merges** on-disk content with the in-memory buffer before writing. No recorder wipes another's entries on `close()`.
+
+## Limitations & gotchas
+
+- **Streaming is passthrough only.** `RecordingProvider.stream()` delegates to the wrapped provider and does **not** capture tokens. Replay of streamed runs is not supported yet.
+- **`step_id` must be unique within a workflow** for the step-id matching to be useful. Steps run inside a loop share the same `step_id` and will collide — use prompt-hash matching or give each iteration a distinct id.
+- **Prompt hashes are sensitive to message formatting.** A trailing space or reordered tool-result block changes the hash. If replay misses, inspect `provider.calls` to see what was tried.
+- **Recordings are not encrypted.** Treat them as you would any captured LLM output — scrub PII before committing.
+- **No built-in TTL.** Recordings live on disk until deleted. For hot-path caching across distributed workers, a pluggable store backend is on the roadmap.
+
+## See also
+
+- [Providers](providers.md) — gateway, circuit breaker, fallback
+- [Observability](observability.md) — metrics, dashboards, OTel setup
+- [`scripts/validate_mock_provider.py`](https://github.com/cchinchilla-dev/agentloom) — end-to-end validation script

--- a/docs/testing-and-replay.md
+++ b/docs/testing-and-replay.md
@@ -106,8 +106,8 @@ async def test_summarization_workflow():
     provider = MockProvider(responses_file="tests/fixtures/summary.json")
     gateway = ProviderGateway()
     gateway.register(provider)
-    engine = WorkflowEngine(gateway=gateway)
-    result = await engine.run(workflow)
+    engine = WorkflowEngine(workflow=workflow, provider_gateway=gateway)
+    result = await engine.run()
     assert result.state["summary"] == "expected output"
 ```
 
@@ -140,7 +140,9 @@ The stock Grafana dashboard includes a **Mock & Replay** row with:
 
 ## Concurrency & merge semantics
 
-If a workflow registers multiple providers each wrapped with `RecordingProvider` pointing to the same file (e.g. primary + fallback via the gateway), `_flush()` **merges** on-disk content with the in-memory buffer before writing. No recorder wipes another's entries on `close()`.
+If a workflow registers multiple providers each wrapped with `RecordingProvider` pointing to the same file (e.g. primary + fallback via the gateway), `_flush()` reads existing on-disk content and merges it with the in-memory buffer before writing.
+
+This is **best-effort**, not concurrency-safe: the implementation is a read-merge-write cycle without locking, so true concurrent writers (multiple processes, or parallel flushes across tasks) can still lose updates. In practice it covers the common case — recorders inside the same run flushing sequentially per call — but if you need strict guarantees, use a single writer or serialize access externally.
 
 ## Limitations & gotchas
 

--- a/examples/31_record_and_replay.yaml
+++ b/examples/31_record_and_replay.yaml
@@ -1,0 +1,32 @@
+name: record-and-replay
+version: "1.0"
+description: |
+  Demonstrates deterministic replay. Run once with --record against a real
+  provider to capture responses, then replay offline forever with
+  --mock-responses. Great for CI, tests, and statistical evaluation without
+  paying per-run.
+
+config:
+  provider: anthropic
+  model: claude-sonnet-4-20250514
+  max_retries: 2
+
+state:
+  topic: "the Byzantine Generals Problem"
+
+steps:
+  - id: explain
+    type: llm_call
+    prompt: "Explain {state.topic} in exactly two sentences."
+    output: explanation
+
+  - id: critique
+    type: llm_call
+    prompt: |
+      Here is an explanation of {state.topic}:
+
+      {state.explanation}
+
+      List one thing this explanation gets wrong or oversimplifies.
+    output: critique
+    depends_on: [explain]

--- a/examples/README.md
+++ b/examples/README.md
@@ -217,3 +217,18 @@ agentloom runs
 # Resume a failed or interrupted run
 agentloom resume <run_id> --lite
 ```
+
+### 31 — Record & Replay
+Two-step workflow. Run once with `--record` to capture real LLM responses to
+a JSON file, then replay offline forever with `--mock-responses` — no network,
+no API key, byte-identical output.
+Demonstrates: `RecordingProvider`, `MockProvider`, deterministic replay for CI
+and statistical evaluation.
+
+```bash
+# Capture a real run (requires ANTHROPIC_API_KEY)
+agentloom run examples/31_record_and_replay.yaml --record recordings/run1.json
+
+# Replay offline — no network, no key, no cost
+agentloom run examples/31_record_and_replay.yaml --mock-responses recordings/run1.json
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
   - Python DSL: python-dsl.md
   - Graph API: graph-api.md
   - Examples: examples.md
+  - Testing & Replay: testing-and-replay.md
   - Observability: observability.md
   - Deployment: deployment.md
   - Contributing: contributing.md

--- a/scripts/validate_mock_provider.py
+++ b/scripts/validate_mock_provider.py
@@ -1,0 +1,129 @@
+"""Functional validation of MockProvider + RecordingProvider.
+
+Exercises the full record → replay round-trip end-to-end:
+
+1. Record: wrap a deterministic fake provider with RecordingProvider, run a
+   2-step workflow, verify the JSON file is written with both step entries.
+2. Replay: load the recorded JSON into MockProvider, run the same workflow,
+   verify outputs and token/cost figures match the recording exactly.
+3. Miss: run against an unrelated prompt, verify the default_response path.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import anyio
+
+from agentloom.core.engine import WorkflowEngine
+from agentloom.core.models import (
+    StepDefinition,
+    StepType,
+    WorkflowConfig,
+    WorkflowDefinition,
+)
+from agentloom.core.results import TokenUsage, WorkflowStatus
+from agentloom.providers.base import BaseProvider, ProviderResponse
+from agentloom.providers.gateway import ProviderGateway
+from agentloom.providers.mock import MockProvider
+from agentloom.providers.recorder import RecordingProvider
+
+
+class DeterministicProvider(BaseProvider):
+    name = "det"
+
+    async def complete(
+        self, messages: list[dict[str, Any]], model: str, **kwargs: Any
+    ) -> ProviderResponse:
+        # Echo the last user content — deterministic so record/replay is comparable.
+        last = messages[-1].get("content", "")
+        return ProviderResponse(
+            content=f"det::{last}",
+            model=model,
+            provider="det",
+            usage=TokenUsage(prompt_tokens=5, completion_tokens=7, total_tokens=12),
+            cost_usd=0.0001,
+            finish_reason="stop",
+        )
+
+    def supports_model(self, model: str) -> bool:
+        return True
+
+
+def _workflow(provider_name: str) -> WorkflowDefinition:
+    return WorkflowDefinition(
+        name="mock-validation",
+        config=WorkflowConfig(provider=provider_name, model="test-model"),
+        state={"question": "what is 2+2"},
+        steps=[
+            StepDefinition(
+                id="draft",
+                type=StepType.LLM_CALL,
+                prompt="Draft: {state.question}",
+                output="draft_text",
+            ),
+            StepDefinition(
+                id="polish",
+                type=StepType.LLM_CALL,
+                depends_on=["draft"],
+                prompt="Polish: {state.draft_text}",
+                output="polished",
+            ),
+        ],
+    )
+
+
+async def main() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        recording = Path(td) / "recording.json"
+
+        print("[1/3] Recording from DeterministicProvider...")
+        gw = ProviderGateway()
+        gw.register(RecordingProvider(DeterministicProvider(), recording), priority=0)
+        engine = WorkflowEngine(workflow=_workflow("det"), provider_gateway=gw)
+        r = await engine.run()
+        await gw.close()
+        assert r.status == WorkflowStatus.SUCCESS, f"record run failed: {r.status}"
+        assert recording.exists(), "recording file not created"
+        data = json.loads(recording.read_text())
+        assert len(data) == 2, f"expected 2 recorded entries, got {len(data)}: {list(data)}"
+        for key, entry in data.items():
+            assert entry["content"].startswith("det::"), entry
+            assert entry["usage"]["total_tokens"] == 12
+            assert "latency_ms" in entry
+        draft_out = r.final_state["draft_text"]
+        polished_out = r.final_state["polished"]
+        print(f"  OK: recorded 2 entries → {recording.name}")
+
+        print("[2/3] Replaying via MockProvider...")
+        gw2 = ProviderGateway()
+        gw2.register(MockProvider(responses_file=recording), priority=0)
+        engine2 = WorkflowEngine(workflow=_workflow("mock"), provider_gateway=gw2)
+        r2 = await engine2.run()
+        await gw2.close()
+        assert r2.status == WorkflowStatus.SUCCESS, f"replay failed: {r2.status}"
+        assert r2.final_state["draft_text"] == draft_out, "replay diverged on draft"
+        assert r2.final_state["polished"] == polished_out, "replay diverged on polish"
+        assert r2.total_tokens == r.total_tokens, (
+            f"token total drift: {r.total_tokens} → {r2.total_tokens}"
+        )
+        print(f"  OK: outputs + tokens match record (tokens={r2.total_tokens})")
+
+        print("[3/3] Verifying default_response on unknown prompt...")
+        mock = MockProvider(responses_file=recording, default_response="FALLBACK")
+        resp = await mock.complete(
+            messages=[{"role": "user", "content": "completely-unseen-input"}],
+            model="test-model",
+        )
+        assert resp.content == "FALLBACK", resp.content
+        assert resp.usage.total_tokens == 0
+        print("  OK: unknown prompt → default_response")
+
+    print("\nAll MockProvider validations passed!")
+
+
+if __name__ == "__main__":
+    anyio.run(main)

--- a/src/agentloom/cli/run.py
+++ b/src/agentloom/cli/run.py
@@ -34,6 +34,12 @@ def run(
     checkpoint_dir: str = typer.Option(
         ".agentloom/checkpoints", "--checkpoint-dir", help="Checkpoint storage directory."
     ),
+    mock_responses: Path | None = typer.Option(
+        None, "--mock-responses", help="Replay responses from a JSON file via MockProvider."
+    ),
+    record: Path | None = typer.Option(
+        None, "--record", help="Record provider responses to a JSON file for later replay."
+    ),
 ) -> None:
     """Execute a workflow from a YAML definition file."""
     anyio.run(
@@ -48,6 +54,8 @@ def run(
         stream,
         checkpoint,
         checkpoint_dir,
+        mock_responses,
+        record,
     )
 
 
@@ -62,6 +70,8 @@ async def _run_async(
     stream: bool = False,
     checkpoint: bool = False,
     checkpoint_dir: str = ".agentloom/checkpoints",
+    mock_responses: Path | None = None,
+    record: Path | None = None,
 ) -> None:
     """Async implementation of the run command."""
     from agentloom.core.engine import WorkflowEngine
@@ -70,14 +80,12 @@ async def _run_async(
     from agentloom.tools.registry import ToolRegistry
     from agentloom.tools.sandbox import ToolSandbox
 
-    # Parse workflow
     try:
         workflow = WorkflowParser.from_yaml(workflow_path)
     except Exception as e:
         typer.echo(f"Error loading workflow: {e}", err=True)
         raise typer.Exit(1)
 
-    # Apply overrides
     if provider_override:
         workflow.config.provider = provider_override
     if model_override:
@@ -87,7 +95,6 @@ async def _run_async(
     if stream:
         workflow.config.stream = True
 
-    # Parse state overrides
     initial_state = dict(workflow.state)
     for item in state_args:
         if "=" not in item:
@@ -98,11 +105,30 @@ async def _run_async(
 
     state_manager = StateManager(initial_state=initial_state)
 
-    # Setup provider gateway
     gateway = ProviderGateway()
-    _setup_providers(gateway, workflow.config.provider)
+    # Setup observability (unless --lite) — done early so providers can hook into it
+    observer = _setup_observer(lite)
 
-    # Setup tools with sandbox from workflow config
+    if mock_responses is not None:
+        from agentloom.providers.mock import MockProvider
+
+        workflow.config.provider = "mock"
+        gateway.register(
+            MockProvider(
+                responses_file=mock_responses,
+                observer=observer,
+                workflow_name=workflow.name,
+            ),
+            priority=0,
+        )
+    else:
+        _setup_providers(gateway, workflow.config.provider)
+        if record is not None:
+            from agentloom.providers.recorder import RecordingProvider
+
+            for entry in list(gateway._providers):
+                entry.provider = RecordingProvider(entry.provider, record, observer=observer)
+
     sandbox_cfg = workflow.config.sandbox
     sandbox = ToolSandbox(
         enabled=sandbox_cfg.enabled,
@@ -117,10 +143,6 @@ async def _run_async(
     tool_registry = ToolRegistry()
     register_builtins(tool_registry, sandbox=sandbox)
 
-    # Setup observability (unless --lite)
-    observer = _setup_observer(lite)
-
-    # Setup stream callback
     stream_callback = None
     if stream and not output_json:
 
@@ -129,14 +151,12 @@ async def _run_async(
 
         stream_callback = _on_chunk
 
-    # Setup checkpointer
     checkpointer = None
     if checkpoint:
         from agentloom.checkpointing.file import FileCheckpointer
 
         checkpointer = FileCheckpointer(checkpoint_dir=checkpoint_dir)
 
-    # Run engine
     engine = WorkflowEngine(
         workflow=workflow,
         state_manager=state_manager,
@@ -279,7 +299,6 @@ def _print_result(result: object) -> None:
             line += f" [{sr.attachment_count} attachment{'s' if sr.attachment_count > 1 else ''}]"
         typer.echo(line)
 
-    # Show final output
     final_state = r.final_state
     typer.echo(f"\nFinal State Keys: {list(final_state.keys())}")
     typer.echo(f"{'=' * 60}")

--- a/src/agentloom/cli/run.py
+++ b/src/agentloom/cli/run.py
@@ -145,8 +145,6 @@ async def _run_async(
     tool_registry = ToolRegistry()
     register_builtins(tool_registry, sandbox=sandbox)
 
-    observer = _setup_observer(lite)
-
     stream_callback = None
     if stream and not output_json:
 

--- a/src/agentloom/cli/run.py
+++ b/src/agentloom/cli/run.py
@@ -131,8 +131,9 @@ async def _run_async(
         if record is not None:
             from agentloom.providers.recorder import RecordingProvider
 
-            for entry in list(gateway._providers):
-                entry.provider = RecordingProvider(entry.provider, record, observer=observer)
+            gateway.wrap_providers(
+                lambda p: RecordingProvider(p, record, observer=observer)
+            )
 
     sandbox_cfg = workflow.config.sandbox
     sandbox = ToolSandbox(

--- a/src/agentloom/cli/run.py
+++ b/src/agentloom/cli/run.py
@@ -42,6 +42,11 @@ def run(
     ),
 ) -> None:
     """Execute a workflow from a YAML definition file."""
+    if mock_responses is not None and record is not None:
+        typer.echo(
+            "Error: --mock-responses and --record are mutually exclusive.", err=True
+        )
+        raise typer.Exit(2)
     anyio.run(
         _run_async,
         workflow_path,

--- a/src/agentloom/cli/run.py
+++ b/src/agentloom/cli/run.py
@@ -43,9 +43,7 @@ def run(
 ) -> None:
     """Execute a workflow from a YAML definition file."""
     if mock_responses is not None and record is not None:
-        typer.echo(
-            "Error: --mock-responses and --record are mutually exclusive.", err=True
-        )
+        typer.echo("Error: --mock-responses and --record are mutually exclusive.", err=True)
         raise typer.Exit(2)
     anyio.run(
         _run_async,
@@ -131,9 +129,7 @@ async def _run_async(
         if record is not None:
             from agentloom.providers.recorder import RecordingProvider
 
-            gateway.wrap_providers(
-                lambda p: RecordingProvider(p, record, observer=observer)
-            )
+            gateway.wrap_providers(lambda p: RecordingProvider(p, record, observer=observer))
 
     sandbox_cfg = workflow.config.sandbox
     sandbox = ToolSandbox(

--- a/src/agentloom/observability/metrics.py
+++ b/src/agentloom/observability/metrics.py
@@ -61,6 +61,9 @@ class MetricsManager:
         self._attachment_counter: Any = None
         self._stream_counter: Any = None
         self._ttft_histogram: Any = None
+        self._mock_replay_counter: Any = None
+        self._recording_capture_counter: Any = None
+        self._recording_latency_histogram: Any = None
         self._circuit_states: dict[str, int] = {}  # provider -> state int
         self._budget_remaining: dict[str, float] = {}  # workflow -> remaining USD
 
@@ -76,8 +79,6 @@ class MetricsManager:
             self._setup_otel(endpoint)
         elif _HAS_PROM:  # pragma: no cover — prom fallback, only active when OTel unavailable
             self._setup_prom()
-
-    # Setup
 
     def _setup_otel(self, endpoint: str) -> None:
         exporter = otel_metric_exporter.OTLPMetricExporter(endpoint=endpoint, insecure=True)
@@ -151,6 +152,19 @@ class MetricsManager:
         self._webhook_histogram = meter.create_histogram(
             "agentloom_webhook_latency_seconds",
             description="Webhook delivery latency",
+            unit="s",
+        )
+        self._mock_replay_counter = meter.create_counter(
+            "agentloom_mock_replays_total",
+            description="Total MockProvider replay lookups",
+        )
+        self._recording_capture_counter = meter.create_counter(
+            "agentloom_recording_captures_total",
+            description="Total RecordingProvider captures",
+        )
+        self._recording_latency_histogram = meter.create_histogram(
+            "agentloom_recording_latency_seconds",
+            description="Latency of real provider calls captured by RecordingProvider",
             unit="s",
         )
 
@@ -251,6 +265,26 @@ class MetricsManager:
             "Total webhook delivery attempts",
             ["status", "workflow"],
         )
+        self._prom_counters["mock_replays"] = prom.Counter(  # pragma: no cover — prom fallback
+            "agentloom_mock_replays_total",
+            "Total MockProvider replay lookups",
+            ["workflow", "matched_by"],
+        )
+        self._prom_counters["recording_captures"] = (
+            prom.Counter(  # pragma: no cover — prom fallback
+                "agentloom_recording_captures_total",
+                "Total RecordingProvider captures",
+                ["provider", "model"],
+            )
+        )
+        self._prom_histograms["recording_latency"] = (
+            prom.Histogram(  # pragma: no cover — prom fallback
+                "agentloom_recording_latency_seconds",
+                "Latency of real provider calls captured by RecordingProvider",
+                ["provider", "model"],
+                buckets=[0.1, 0.5, 1, 2, 5, 10, 30],
+            )
+        )
         self._prom_histograms["webhook_latency"] = prom.Histogram(  # pragma: no cover
             "agentloom_webhook_latency_seconds",
             "Webhook delivery latency",
@@ -269,8 +303,6 @@ class MetricsManager:
         )
         self._backend = "prom"
         logger.debug("Metrics: prometheus_client (pull)")
-
-    # Recording
 
     def record_workflow_run(
         self, workflow: str, status: str, duration_s: float = 0.0, cost_usd: float = 0.0
@@ -403,6 +435,32 @@ class MetricsManager:
             self._prom_counters["webhook_deliveries"].labels(status=status, workflow=workflow).inc()
             self._prom_histograms["webhook_latency"].labels(status=status).observe(latency_s)
 
+    def record_mock_replay(self, workflow: str, matched_by: str) -> None:
+        """Record a MockProvider lookup. ``matched_by`` ∈ {step_id, prompt_hash, default}."""
+        if not self._enabled:
+            return
+        if self._backend == "otel":
+            self._mock_replay_counter.add(1, {"workflow": workflow, "matched_by": matched_by})
+        else:  # pragma: no cover — prom fallback
+            self._prom_counters["mock_replays"].labels(
+                workflow=workflow, matched_by=matched_by
+            ).inc()
+
+    def record_recording_capture(self, provider: str, model: str, latency_s: float) -> None:
+        """Record a RecordingProvider capture of a real provider call."""
+        if not self._enabled:
+            return
+        if self._backend == "otel":
+            self._recording_capture_counter.add(1, {"provider": provider, "model": model})
+            self._recording_latency_histogram.record(
+                latency_s, {"provider": provider, "model": model}
+            )
+        else:  # pragma: no cover — prom fallback
+            self._prom_counters["recording_captures"].labels(provider=provider, model=model).inc()
+            self._prom_histograms["recording_latency"].labels(
+                provider=provider, model=model
+            ).observe(latency_s)
+
     def set_budget_remaining(self, workflow: str, remaining: float) -> None:
         if not self._enabled:
             return
@@ -415,11 +473,8 @@ class MetricsManager:
             return
         # OTel: update dict read by the observable gauge callback
         self._circuit_states[provider] = state
-        # Prometheus fallback
         if self._backend == "prom":  # pragma: no cover — prom fallback
             self._prom_gauges["circuit_state"].labels(provider=provider).set(state)
-
-    # Lifecycle
 
     def shutdown(self) -> None:
         """Flush pending metrics before process exit."""

--- a/src/agentloom/observability/observer.py
+++ b/src/agentloom/observability/observer.py
@@ -33,8 +33,6 @@ class WorkflowObserver:
         self._workflow_span: Any | None = None
         self._step_spans: dict[str, Any] = {}
 
-    # Workflow lifecycle
-
     def on_workflow_start(self, workflow_name: str) -> None:
         if self._tracing:
             self._workflow_span = self._tracing.start_span(
@@ -50,13 +48,11 @@ class WorkflowObserver:
         total_tokens: int,
         total_cost: float,
     ) -> None:
-        # Metrics
         if self._metrics:
             self._metrics.record_workflow_run(
                 workflow_name, status, duration_ms / 1000.0, total_cost
             )
 
-        # Span
         span = self._workflow_span
         if span:
             span.set_attribute("workflow.status", status)
@@ -68,8 +64,6 @@ class WorkflowObserver:
             else:
                 span.end()
             self._workflow_span = None
-
-    # Step lifecycle
 
     def on_step_start(self, step_id: str, step_type: str, stream: bool = False) -> None:
         if self._tracing:
@@ -96,7 +90,6 @@ class WorkflowObserver:
         time_to_first_token_ms: float | None = None,
         stream: bool = False,
     ) -> None:
-        # Metrics
         if self._metrics:
             self._metrics.record_step_execution(
                 step_type, status, duration_ms / 1000.0, stream=stream
@@ -104,7 +97,6 @@ class WorkflowObserver:
             if attachment_count > 0:
                 self._metrics.record_attachments(step_type, attachment_count)
 
-        # Span
         span = self._step_spans.pop(step_id, None)
         if span:
             span.set_attribute("step.status", status)
@@ -163,8 +155,6 @@ class WorkflowObserver:
         if self._metrics:
             self._metrics.set_circuit_state(provider, state_int)
 
-    # Human-in-the-loop events
-
     def on_approval_gate(self, step_id: str, workflow_name: str, decision: str) -> None:
         if self._metrics:
             self._metrics.record_approval_gate(workflow_name, decision)
@@ -182,13 +172,26 @@ class WorkflowObserver:
             span.set_attribute("webhook.status", status)
             span.set_attribute("webhook.latency_s", latency_s)
 
-    # Budget events
+    def on_mock_replay(self, workflow_name: str, step_id: str, matched_by: str) -> None:
+        if self._metrics:
+            self._metrics.record_mock_replay(workflow_name, matched_by)
+        span = self._step_spans.get(step_id)
+        if span:
+            span.set_attribute("mock.matched_by", matched_by)
+
+    def on_recording_capture(
+        self, step_id: str, provider: str, model: str, latency_s: float
+    ) -> None:
+        if self._metrics:
+            self._metrics.record_recording_capture(provider, model, latency_s)
+        span = self._step_spans.get(step_id)
+        if span:
+            span.set_attribute("recording.provider", provider)
+            span.set_attribute("recording.latency_s", latency_s)
 
     def on_budget_remaining(self, workflow: str, remaining: float) -> None:
         if self._metrics:
             self._metrics.set_budget_remaining(workflow, remaining)
-
-    # Shutdown
 
     def shutdown(self) -> None:
         if self._metrics:

--- a/src/agentloom/observability/observer.py
+++ b/src/agentloom/observability/observer.py
@@ -178,6 +178,8 @@ class WorkflowObserver:
         span = self._step_spans.get(step_id)
         if span:
             span.set_attribute("mock.matched_by", matched_by)
+            if step_id:
+                span.set_attribute("mock.step_id", step_id)
 
     def on_recording_capture(
         self, step_id: str, provider: str, model: str, latency_s: float
@@ -187,6 +189,7 @@ class WorkflowObserver:
         span = self._step_spans.get(step_id)
         if span:
             span.set_attribute("recording.provider", provider)
+            span.set_attribute("recording.model", model)
             span.set_attribute("recording.latency_s", latency_s)
 
     def on_budget_remaining(self, workflow: str, remaining: float) -> None:

--- a/src/agentloom/providers/gateway.py
+++ b/src/agentloom/providers/gateway.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from typing import Any
 
 from agentloom.exceptions import CircuitOpenError, ProviderError
@@ -91,6 +91,17 @@ class ProviderGateway:
             self._model_mapping.setdefault(model, []).append(entry)
             self._model_mapping[model].sort(key=lambda e: e.priority)
 
+        self._candidate_cache.clear()
+
+    def wrap_providers(self, factory: Callable[[BaseProvider], BaseProvider]) -> None:
+        """Replace each registered provider with ``factory(provider)``.
+
+        Useful for cross-cutting wrappers (e.g. ``RecordingProvider``) that
+        need to intercept every registered provider without the caller
+        knowing their concrete types or internal entry layout.
+        """
+        for entry in self._providers:
+            entry.provider = factory(entry.provider)
         self._candidate_cache.clear()
 
     def _wire_circuit_callback(self, entry: ProviderEntry) -> None:

--- a/src/agentloom/providers/mock.py
+++ b/src/agentloom/providers/mock.py
@@ -1,0 +1,161 @@
+"""Mock provider — deterministic replay for tests and offline evaluation.
+
+Responses are loaded from a JSON file keyed by either ``step_id`` or the
+SHA-256 hash of the serialized messages. Latency is simulated via
+``latency_model`` (``constant``, ``normal``, ``replay``).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import json
+import random
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+import anyio
+
+from agentloom.core.results import TokenUsage
+from agentloom.providers.base import BaseProvider, ProviderResponse
+
+
+@runtime_checkable
+class MockObserver(Protocol):
+    """Minimal observer interface for MockProvider replay events."""
+
+    def on_mock_replay(self, workflow_name: str, step_id: str, matched_by: str) -> None: ...
+
+
+def prompt_hash(messages: list[dict[str, Any]]) -> str:
+    """Stable SHA-256 hash of a messages list for response keying."""
+    payload = json.dumps(messages, sort_keys=True, default=str).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+class MockProvider(BaseProvider):
+    """Deterministic provider that returns pre-recorded responses.
+
+    Response file format::
+
+        {
+          "<key>": {
+            "content": "...",
+            "model": "gpt-4o-mini",
+            "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+            "cost_usd": 0.001,
+            "latency_ms": 120.0,
+            "finish_reason": "stop"
+          }
+        }
+
+    ``<key>`` is either a step_id (if the caller passes ``step_id=`` through
+    kwargs) or the SHA-256 hash of the serialized messages.
+    """
+
+    name = "mock"
+
+    def __init__(
+        self,
+        api_key: str = "",
+        base_url: str = "",
+        responses_file: str | Path | None = None,
+        latency_model: str = "constant",
+        latency_ms: float = 0.0,
+        default_response: str = "Mock response",
+        seed: int | None = None,
+        observer: MockObserver | None = None,
+        workflow_name: str = "unknown",
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(api_key=api_key, base_url=base_url)
+        self.responses_file = Path(responses_file) if responses_file else None
+        self.latency_model = latency_model
+        self.latency_ms = float(latency_ms)
+        self.default_response = default_response
+        self._rng = random.Random(seed)
+        self._observer = observer
+        self._workflow_name = workflow_name
+        self.calls: list[dict[str, Any]] = []
+        self._responses: dict[str, dict[str, Any]] = {}
+        if self.responses_file and self.responses_file.exists():
+            raw = json.loads(self.responses_file.read_text())
+            if not isinstance(raw, dict):
+                raise ValueError(f"responses_file {self.responses_file} must contain a JSON object")
+            self._responses = raw
+
+    def _lookup(self, step_id: str | None, messages: list[dict[str, Any]]) -> dict[str, Any] | None:
+        if step_id and step_id in self._responses:
+            return self._responses[step_id]
+        key = prompt_hash(messages)
+        return self._responses.get(key)
+
+    async def _sleep(self, recorded_ms: float | None) -> None:
+        if self.latency_model == "replay" and recorded_ms is not None:
+            delay = recorded_ms
+        elif self.latency_model == "normal":
+            sigma = max(self.latency_ms * 0.1, 1.0)
+            delay = max(0.0, self._rng.gauss(self.latency_ms, sigma))
+        else:  # constant
+            delay = self.latency_ms
+        if delay > 0:
+            await anyio.sleep(delay / 1000.0)
+
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> ProviderResponse:
+        step_id = kwargs.get("step_id")
+        entry = self._lookup(step_id, messages)
+        if entry is None:
+            matched_by = "default"
+        elif step_id and step_id in self._responses:
+            matched_by = "step_id"
+        else:
+            matched_by = "prompt_hash"
+        self.calls.append(
+            {
+                "step_id": step_id,
+                "model": model,
+                "messages": messages,
+                "matched": entry is not None,
+                "matched_by": matched_by,
+            }
+        )
+        if self._observer is not None:
+            # observer must never break replay
+            with contextlib.suppress(Exception):  # pragma: no cover
+                self._observer.on_mock_replay(self._workflow_name, step_id or "", matched_by)
+        recorded_latency = entry.get("latency_ms") if entry else None
+        await self._sleep(recorded_latency if isinstance(recorded_latency, int | float) else None)
+
+        if entry is None:
+            return ProviderResponse(
+                content=self.default_response,
+                model=model,
+                provider=self.name,
+                usage=TokenUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+                cost_usd=0.0,
+                finish_reason="stop",
+            )
+
+        usage_data = entry.get("usage", {}) or {}
+        return ProviderResponse(
+            content=str(entry.get("content", "")),
+            model=str(entry.get("model", model)),
+            provider=self.name,
+            usage=TokenUsage(
+                prompt_tokens=int(usage_data.get("prompt_tokens", 0)),
+                completion_tokens=int(usage_data.get("completion_tokens", 0)),
+                total_tokens=int(usage_data.get("total_tokens", 0)),
+            ),
+            cost_usd=float(entry.get("cost_usd", 0.0)),
+            finish_reason=entry.get("finish_reason", "stop"),
+        )
+
+    def supports_model(self, model: str) -> bool:
+        return True

--- a/src/agentloom/providers/recorder.py
+++ b/src/agentloom/providers/recorder.py
@@ -12,6 +12,8 @@ import time
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
+import anyio
+
 from agentloom.providers.base import BaseProvider, ProviderResponse, StreamResponse
 from agentloom.providers.mock import prompt_hash
 
@@ -56,7 +58,10 @@ class RecordingProvider(BaseProvider):
     def _key(self, step_id: str | None, messages: list[dict[str, Any]]) -> str:
         return step_id if step_id else prompt_hash(messages)
 
-    def _flush(self) -> None:
+    async def _flush(self) -> None:
+        await anyio.to_thread.run_sync(self._flush_sync)
+
+    def _flush_sync(self) -> None:
         self.output_path.parent.mkdir(parents=True, exist_ok=True)
         # Merge with any existing on-disk content so concurrent recorders
         # (e.g. wrapping multiple providers in a gateway) don't clobber
@@ -99,7 +104,7 @@ class RecordingProvider(BaseProvider):
             "latency_ms": latency_ms,
             "finish_reason": response.finish_reason,
         }
-        self._flush()
+        await self._flush()
         if self._observer is not None:
             # observer must never break capture
             with contextlib.suppress(Exception):  # pragma: no cover
@@ -128,5 +133,5 @@ class RecordingProvider(BaseProvider):
         return self._wrapped.supports_model(model)
 
     async def close(self) -> None:
-        self._flush()
+        await self._flush()
         await self._wrapped.close()

--- a/src/agentloom/providers/recorder.py
+++ b/src/agentloom/providers/recorder.py
@@ -1,0 +1,132 @@
+"""Recording provider — wraps a real provider and captures responses to JSON.
+
+The captured file is directly loadable by :class:`MockProvider` for
+deterministic replay.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import time
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from agentloom.providers.base import BaseProvider, ProviderResponse, StreamResponse
+from agentloom.providers.mock import prompt_hash
+
+
+@runtime_checkable
+class RecordingObserver(Protocol):
+    """Minimal observer interface for RecordingProvider capture events."""
+
+    def on_recording_capture(
+        self, step_id: str, provider: str, model: str, latency_s: float
+    ) -> None: ...
+
+
+class RecordingProvider(BaseProvider):
+    """Delegates to a wrapped provider and records each completion.
+
+    Responses are keyed by ``step_id`` when present, otherwise by the SHA-256
+    hash of the serialized messages. The file is flushed on every call so a
+    crashed workflow still leaves a partial recording on disk.
+    """
+
+    def __init__(
+        self,
+        wrapped: BaseProvider,
+        output_path: str | Path,
+        observer: RecordingObserver | None = None,
+    ) -> None:
+        super().__init__(api_key=wrapped.api_key, base_url=wrapped.base_url)
+        self.name = wrapped.name
+        self._wrapped = wrapped
+        self.output_path = Path(output_path)
+        self._observer = observer
+        self._recorded: dict[str, dict[str, Any]] = {}
+        if self.output_path.exists():
+            try:
+                existing = json.loads(self.output_path.read_text())
+                if isinstance(existing, dict):
+                    self._recorded = existing
+            except json.JSONDecodeError:
+                pass
+
+    def _key(self, step_id: str | None, messages: list[dict[str, Any]]) -> str:
+        return step_id if step_id else prompt_hash(messages)
+
+    def _flush(self) -> None:
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        # Merge with any existing on-disk content so concurrent recorders
+        # (e.g. wrapping multiple providers in a gateway) don't clobber
+        # each other on close().
+        merged: dict[str, dict[str, Any]] = {}
+        if self.output_path.exists():
+            try:
+                existing = json.loads(self.output_path.read_text())
+                if isinstance(existing, dict):
+                    merged.update(existing)
+            except json.JSONDecodeError:
+                pass
+        merged.update(self._recorded)
+        self.output_path.write_text(json.dumps(merged, indent=2, default=str))
+
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> ProviderResponse:
+        step_id = kwargs.get("step_id")
+        start = time.perf_counter()
+        response = await self._wrapped.complete(
+            messages=messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+        latency_ms = (time.perf_counter() - start) * 1000.0
+
+        self._recorded[self._key(step_id, messages)] = {
+            "content": response.content,
+            "model": response.model,
+            "usage": response.usage.model_dump(),
+            "cost_usd": response.cost_usd,
+            "latency_ms": latency_ms,
+            "finish_reason": response.finish_reason,
+        }
+        self._flush()
+        if self._observer is not None:
+            # observer must never break capture
+            with contextlib.suppress(Exception):  # pragma: no cover
+                self._observer.on_recording_capture(
+                    step_id or "", response.provider, response.model, latency_ms / 1000.0
+                )
+        return response
+
+    async def stream(
+        self,
+        messages: list[dict[str, Any]],
+        model: str,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        **kwargs: Any,
+    ) -> StreamResponse:
+        return await self._wrapped.stream(
+            messages=messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            **kwargs,
+        )
+
+    def supports_model(self, model: str) -> bool:
+        return self._wrapped.supports_model(model)
+
+    async def close(self) -> None:
+        self._flush()
+        await self._wrapped.close()

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -243,3 +243,105 @@ class TestPrintResult:
             final_state={"draft_output": "hello"},
         )
         _print_result(result)
+
+
+class TestRunRecordAndReplay:
+    def test_record_and_mock_mutually_exclusive(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".yaml", mode="w", delete=False) as f:
+            f.write(SIMPLE_YAML)
+            f.flush()
+            result = runner.invoke(
+                app,
+                [
+                    "run",
+                    f.name,
+                    "--record",
+                    "/tmp/rec.json",
+                    "--mock-responses",
+                    "/tmp/rec.json",
+                ],
+            )
+        assert result.exit_code != 0
+        combined = result.output + (result.stderr or "")
+        assert "mutually exclusive" in combined
+
+    def test_mock_responses_registers_mock_provider(self) -> None:
+        import json
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            rec_path = Path(tmp) / "fix.json"
+            rec_path.write_text(
+                json.dumps(
+                    {
+                        "answer": {
+                            "content": "42",
+                            "model": "mock-model",
+                            "usage": {
+                                "prompt_tokens": 1,
+                                "completion_tokens": 1,
+                                "total_tokens": 2,
+                            },
+                            "cost_usd": 0.0,
+                            "latency_ms": 0.0,
+                            "finish_reason": "stop",
+                        }
+                    }
+                )
+            )
+            yaml_path = Path(tmp) / "wf.yaml"
+            yaml_path.write_text(SIMPLE_YAML)
+            with patch("agentloom.cli.run._setup_observer", return_value=None):
+                result = runner.invoke(
+                    app,
+                    [
+                        "run",
+                        str(yaml_path),
+                        "--mock-responses",
+                        str(rec_path),
+                        "--lite",
+                    ],
+                )
+        assert result.exit_code == 0, f"stdout: {result.output}"
+        assert "'answer'" in result.output
+
+    def test_record_wraps_registered_providers(self) -> None:
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmp:
+            rec_path = Path(tmp) / "out.json"
+            yaml_path = Path(tmp) / "wf.yaml"
+            yaml_path.write_text(SIMPLE_YAML)
+
+            from tests.conftest import MockProvider as TestMock
+
+            captured: dict[str, object] = {}
+
+            def _wire(gw: object, default: str) -> None:
+                from agentloom.providers.gateway import ProviderGateway
+
+                assert isinstance(gw, ProviderGateway)
+                inner = TestMock()
+                gw.register(inner, priority=0)
+                captured["inner"] = inner
+
+            with patch("agentloom.cli.run._setup_providers") as mock_setup:
+                mock_setup.side_effect = _wire
+                with patch("agentloom.cli.run._setup_observer", return_value=None):
+                    result = runner.invoke(
+                        app,
+                        [
+                            "run",
+                            str(yaml_path),
+                            "--record",
+                            str(rec_path),
+                            "--lite",
+                        ],
+                    )
+
+            assert result.exit_code == 0, f"stdout: {result.output}"
+            assert rec_path.exists()
+            import json as _json
+
+            data = _json.loads(rec_path.read_text())
+            assert len(data) == 1

--- a/tests/observability/test_metrics.py
+++ b/tests/observability/test_metrics.py
@@ -27,6 +27,8 @@ class TestMetricsDisabled:
         mm.record_attachments("llm_call", 2)
         mm.record_stream_response("openai", "gpt-4o-mini")
         mm.record_time_to_first_token("openai", "gpt-4o-mini", 0.1)
+        mm.record_mock_replay("wf", "step_id")
+        mm.record_recording_capture("anthropic", "m", 0.5)
         mm.set_budget_remaining("wf", 0.5)
         mm.set_circuit_state("openai", 1)
         mm.shutdown()
@@ -122,6 +124,20 @@ class TestMetricsEnabled:
     def test_record_time_to_first_token(self) -> None:
         mm = MetricsManager(enabled=True)
         mm.record_time_to_first_token("openai", "gpt-4o-mini", 0.25)
+        if mm._backend == "otel":
+            mm.shutdown()
+
+    def test_record_mock_replay(self) -> None:
+        mm = MetricsManager(enabled=True)
+        mm.record_mock_replay("wf", "step_id")
+        mm.record_mock_replay("wf", "prompt_hash")
+        mm.record_mock_replay("wf", "default")
+        if mm._backend == "otel":
+            mm.shutdown()
+
+    def test_record_recording_capture(self) -> None:
+        mm = MetricsManager(enabled=True)
+        mm.record_recording_capture("anthropic", "claude-haiku-4-5-20251001", 0.88)
         if mm._backend == "otel":
             mm.shutdown()
 

--- a/tests/observability/test_observer.py
+++ b/tests/observability/test_observer.py
@@ -138,6 +138,42 @@ class TestHITLEvents:
         observer.on_webhook_delivery("gate", "wf", "success", 0.5)
 
 
+class TestMockAndRecordingEvents:
+    def test_on_mock_replay_records_metrics(self) -> None:
+        metrics = MagicMock()
+        observer = WorkflowObserver(metrics=metrics)
+        observer.on_mock_replay("my-wf", "step_a", "step_id")
+        metrics.record_mock_replay.assert_called_once_with("my-wf", "step_id")
+
+    def test_on_mock_replay_sets_span_attribute(self) -> None:
+        tracing = MagicMock()
+        observer = WorkflowObserver(tracing=tracing)
+        observer.on_step_start("step_a", "llm_call")
+        span = tracing.start_span.return_value
+        observer.on_mock_replay("my-wf", "step_a", "prompt_hash")
+        span.set_attribute.assert_any_call("mock.matched_by", "prompt_hash")
+
+    def test_on_recording_capture_records_metrics(self) -> None:
+        metrics = MagicMock()
+        observer = WorkflowObserver(metrics=metrics)
+        observer.on_recording_capture("step_a", "anthropic", "claude", 0.88)
+        metrics.record_recording_capture.assert_called_once_with("anthropic", "claude", 0.88)
+
+    def test_on_recording_capture_sets_span_attributes(self) -> None:
+        tracing = MagicMock()
+        observer = WorkflowObserver(tracing=tracing)
+        observer.on_step_start("step_a", "llm_call")
+        span = tracing.start_span.return_value
+        observer.on_recording_capture("step_a", "openai", "gpt-4o-mini", 1.2)
+        span.set_attribute.assert_any_call("recording.provider", "openai")
+        span.set_attribute.assert_any_call("recording.latency_s", 1.2)
+
+    def test_no_metrics_no_error(self) -> None:
+        observer = WorkflowObserver()
+        observer.on_mock_replay("wf", "s", "default")
+        observer.on_recording_capture("s", "p", "m", 0.1)
+
+
 class TestBudgetEvents:
     def test_on_budget_remaining(self) -> None:
         metrics = MagicMock()

--- a/tests/providers/test_mock.py
+++ b/tests/providers/test_mock.py
@@ -1,0 +1,121 @@
+"""Tests for MockProvider."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from agentloom.providers.mock import MockProvider, prompt_hash
+
+
+@pytest.fixture
+def responses_file(tmp_path):
+    path = tmp_path / "responses.json"
+    data = {
+        "step_one": {
+            "content": "hello from step_one",
+            "model": "gpt-4o-mini",
+            "usage": {"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+            "cost_usd": 0.0005,
+            "latency_ms": 20.0,
+            "finish_reason": "stop",
+        },
+        prompt_hash([{"role": "user", "content": "hash me"}]): {
+            "content": "by hash",
+            "model": "gpt-4o-mini",
+            "usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3},
+            "cost_usd": 0.0,
+            "latency_ms": 0.0,
+            "finish_reason": "stop",
+        },
+    }
+    path.write_text(json.dumps(data))
+    return path
+
+
+async def test_matches_by_step_id(responses_file):
+    provider = MockProvider(responses_file=responses_file)
+    r = await provider.complete(
+        messages=[{"role": "user", "content": "anything"}],
+        model="gpt-4o-mini",
+        step_id="step_one",
+    )
+    assert r.content == "hello from step_one"
+    assert r.usage.total_tokens == 12
+    assert r.cost_usd == 0.0005
+    assert provider.calls[0]["matched"] is True
+
+
+async def test_matches_by_prompt_hash(responses_file):
+    provider = MockProvider(responses_file=responses_file)
+    r = await provider.complete(
+        messages=[{"role": "user", "content": "hash me"}], model="gpt-4o-mini"
+    )
+    assert r.content == "by hash"
+
+
+async def test_default_response_when_no_match(tmp_path):
+    provider = MockProvider(default_response="fallback!")
+    r = await provider.complete(messages=[{"role": "user", "content": "x"}], model="m")
+    assert r.content == "fallback!"
+    assert r.provider == "mock"
+    assert provider.calls[0]["matched"] is False
+
+
+async def test_replay_latency(responses_file):
+    provider = MockProvider(responses_file=responses_file, latency_model="replay")
+    start = time.perf_counter()
+    await provider.complete(
+        messages=[{"role": "user", "content": "x"}], model="m", step_id="step_one"
+    )
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    assert elapsed_ms >= 15.0  # recorded 20ms, allow slack
+
+
+async def test_constant_latency(tmp_path):
+    provider = MockProvider(latency_model="constant", latency_ms=10.0)
+    start = time.perf_counter()
+    await provider.complete(messages=[{"role": "user", "content": "x"}], model="m")
+    assert (time.perf_counter() - start) * 1000.0 >= 8.0
+
+
+async def test_normal_latency_deterministic_with_seed(tmp_path):
+    provider = MockProvider(latency_model="normal", latency_ms=5.0, seed=42)
+    await provider.complete(messages=[{"role": "user", "content": "x"}], model="m")
+    # just ensures the gaussian branch runs without error
+
+
+async def test_observer_receives_step_id_match(responses_file):
+    calls = []
+
+    class Obs:
+        def on_mock_replay(self, workflow_name, step_id, matched_by):
+            calls.append((workflow_name, step_id, matched_by))
+
+    provider = MockProvider(responses_file=responses_file, observer=Obs(), workflow_name="wf1")
+    await provider.complete(
+        messages=[{"role": "user", "content": "x"}], model="m", step_id="step_one"
+    )
+    assert calls == [("wf1", "step_one", "step_id")]
+
+
+async def test_observer_receives_prompt_hash_and_default(responses_file):
+    calls = []
+
+    class Obs:
+        def on_mock_replay(self, workflow_name, step_id, matched_by):
+            calls.append((workflow_name, step_id, matched_by))
+
+    provider = MockProvider(responses_file=responses_file, observer=Obs(), workflow_name="wf")
+    await provider.complete(messages=[{"role": "user", "content": "hash me"}], model="m")
+    await provider.complete(messages=[{"role": "user", "content": "nothing-matches"}], model="m")
+    assert [c[2] for c in calls] == ["prompt_hash", "default"]
+
+
+def test_rejects_non_object_responses_file(tmp_path):
+    path = tmp_path / "bad.json"
+    path.write_text("[1, 2, 3]")
+    with pytest.raises(ValueError, match="must contain a JSON object"):
+        MockProvider(responses_file=path)

--- a/tests/providers/test_recorder.py
+++ b/tests/providers/test_recorder.py
@@ -120,3 +120,62 @@ async def test_merges_with_existing_file(tmp_path):
     data = json.loads(recording_path.read_text())
     assert "prior" in data
     assert "new_step" in data
+
+
+async def test_ignores_corrupted_existing_file_on_init(tmp_path):
+    recording_path = tmp_path / "corrupt.json"
+    recording_path.write_text("{ not valid json")
+
+    source = MockProvider(default_response="ok")
+    recorder = RecordingProvider(source, recording_path)
+    await recorder.complete(messages=[{"role": "user", "content": "hi"}], model="m", step_id="s1")
+
+    data = json.loads(recording_path.read_text())
+    assert "s1" in data
+
+
+async def test_flush_recovers_from_corrupted_file(tmp_path):
+    recording_path = tmp_path / "corrupt.json"
+    source = MockProvider(default_response="ok")
+    recorder = RecordingProvider(source, recording_path)
+    # Corrupt the file after init but before flush
+    recording_path.write_text("{ still bad")
+
+    await recorder.complete(messages=[{"role": "user", "content": "hi"}], model="m", step_id="s1")
+    data = json.loads(recording_path.read_text())
+    assert "s1" in data
+
+
+async def test_stream_delegates_to_wrapped(tmp_path):
+    called = {}
+
+    class FakeStream:
+        def __init__(self):
+            self.name = "fake"
+            self.api_key = None
+            self.base_url = None
+
+        async def stream(self, **kwargs):
+            called.update(kwargs)
+            return "stream-result"
+
+        async def complete(self, **kwargs):
+            raise NotImplementedError
+
+        def supports_model(self, model):
+            return model == "fake-model"
+
+        async def close(self):
+            pass
+
+    recorder = RecordingProvider(FakeStream(), tmp_path / "r.json")  # type: ignore[arg-type]
+    result = await recorder.stream(messages=[{"role": "user", "content": "hi"}], model="fake-model")
+    assert result == "stream-result"
+    assert called["model"] == "fake-model"
+
+
+async def test_supports_model_delegates_to_wrapped(tmp_path):
+    source = MockProvider(default_response="ok")
+    source.name = "src"
+    recorder = RecordingProvider(source, tmp_path / "r.json")
+    assert recorder.supports_model("any-model") is True

--- a/tests/providers/test_recorder.py
+++ b/tests/providers/test_recorder.py
@@ -1,0 +1,122 @@
+"""Tests for RecordingProvider."""
+
+from __future__ import annotations
+
+import json
+
+from agentloom.providers.mock import MockProvider, prompt_hash
+from agentloom.providers.recorder import RecordingProvider
+
+
+async def test_records_then_replays(tmp_path):
+    # Source provider: a mock with a known response
+    src_file = tmp_path / "src.json"
+    src_file.write_text(
+        json.dumps(
+            {
+                "s1": {
+                    "content": "captured",
+                    "model": "gpt-4o-mini",
+                    "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+                    "cost_usd": 0.002,
+                    "finish_reason": "stop",
+                }
+            }
+        )
+    )
+    source = MockProvider(responses_file=src_file)
+
+    recording_path = tmp_path / "recorded.json"
+    recorder = RecordingProvider(source, recording_path)
+
+    messages = [{"role": "user", "content": "record me"}]
+    r = await recorder.complete(messages=messages, model="gpt-4o-mini", step_id="s1")
+    assert r.content == "captured"
+
+    # File is flushed per-call
+    data = json.loads(recording_path.read_text())
+    assert "s1" in data
+    assert data["s1"]["content"] == "captured"
+    assert data["s1"]["usage"]["total_tokens"] == 7
+    assert "latency_ms" in data["s1"]
+
+    # Replay via a fresh MockProvider from the recorded file
+    replay = MockProvider(responses_file=recording_path)
+    r2 = await replay.complete(messages=messages, model="gpt-4o-mini", step_id="s1")
+    assert r2.content == "captured"
+
+
+async def test_records_by_prompt_hash_when_no_step_id(tmp_path):
+    source = MockProvider(default_response="ok")
+    recording_path = tmp_path / "out.json"
+    recorder = RecordingProvider(source, recording_path)
+
+    messages = [{"role": "user", "content": "nohash"}]
+    await recorder.complete(messages=messages, model="m")
+
+    data = json.loads(recording_path.read_text())
+    assert prompt_hash(messages) in data
+
+
+async def test_close_flushes_and_closes_wrapped(tmp_path):
+    source = MockProvider(default_response="x")
+    recording_path = tmp_path / "out.json"
+    recorder = RecordingProvider(source, recording_path)
+    await recorder.close()
+    # file exists (empty dict) after close
+    assert recording_path.exists()
+    assert json.loads(recording_path.read_text()) == {}
+
+
+async def test_observer_notified_on_capture(tmp_path):
+    source = MockProvider(default_response="ok")
+    source.name = "det"
+    events = []
+
+    class Obs:
+        def on_recording_capture(self, step_id, provider, model, latency_s):
+            events.append((step_id, provider, model, latency_s))
+
+    recorder = RecordingProvider(source, tmp_path / "out.json", observer=Obs())
+    await recorder.complete(messages=[{"role": "user", "content": "hi"}], model="m", step_id="s1")
+    assert len(events) == 1
+    step_id, provider, model, latency_s = events[0]
+    assert step_id == "s1"
+    assert provider == "det"
+    assert model == "m"
+    assert latency_s >= 0.0
+
+
+async def test_multiple_recorders_same_path_do_not_clobber(tmp_path):
+    """Regression: two RecordingProviders on the same path must accumulate,
+    not overwrite each other's entries on close()."""
+    path = tmp_path / "shared.json"
+
+    rec_a = RecordingProvider(MockProvider(default_response="a"), path)
+    rec_b = RecordingProvider(MockProvider(default_response="b"), path)
+
+    await rec_a.complete(messages=[{"role": "user", "content": "m1"}], model="m", step_id="from_a")
+    await rec_b.complete(messages=[{"role": "user", "content": "m2"}], model="m", step_id="from_b")
+
+    # close() in reverse order — the one with the emptier history must not wipe
+    await rec_b.close()
+    await rec_a.close()
+
+    data = json.loads(path.read_text())
+    assert "from_a" in data
+    assert "from_b" in data
+
+
+async def test_merges_with_existing_file(tmp_path):
+    recording_path = tmp_path / "out.json"
+    recording_path.write_text(json.dumps({"prior": {"content": "old"}}))
+
+    source = MockProvider(default_response="new")
+    recorder = RecordingProvider(source, recording_path)
+    await recorder.complete(
+        messages=[{"role": "user", "content": "a"}], model="m", step_id="new_step"
+    )
+
+    data = json.loads(recording_path.read_text())
+    assert "prior" in data
+    assert "new_step" in data


### PR DESCRIPTION
## What

Deterministic LLM replay via `MockProvider` and `RecordingProvider`. Capture real provider responses once with `--record`, then replay offline forever with `--mock-responses` — no network, no API key, byte-identical output.

- `RecordingProvider` wraps any upstream provider and persists responses to a JSON file, merge-on-flush so concurrent recorders don't clobber each other
- `MockProvider` replays from a recording keyed by `step_id` → SHA-256 prompt hash → `default_response`, with three latency models (`constant`, `normal`, `replay`)
- CLI flags `--record <path>` and `--mock-responses <path>` wired into `agentloom run`
- Observer + Prometheus metrics: `agentloom_mock_replays_total`, `agentloom_recording_captures_total`
- Grafana dashboard row "Mock & Replay" with replay rate, capture rate, and latency panels
- Example workflow (`examples/31_record_and_replay.yaml`), K8s Job template, and validation script

## Why

Testing workflows against real providers is slow, flaky, and expensive. Existing frameworks leave this to the user. With record/replay, CI runs are reproducible and free, statistical evaluations don't burn budget per iteration, and regression tests are byte-identical across runs. No SaaS, no vendor lock-in — responses are plain JSON on disk.

## Testing

- [x] `uv run pytest` passes (848 tests)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format src/ tests/` clean
- [x] End-to-end: `--record` against Anthropic (claude-sonnet-4) captured 2 steps / 375 tokens / \$0.0040 in 8.1s
- [x] End-to-end: `--mock-responses` replay offline (no key) in 2.1ms, same final state
- [x] Grafana row renders with replay and capture panels

## Notes

- Recording format is plain JSON keyed by SHA-256 of messages; `step_id` overrides when present
- Merge-on-flush lets parallel recorders share a file without locking
- Streaming is passed through during recording but replays are buffered (documented limitation)

Closes #61
Closes #76