### PR TITLE
clean up decorative comments and align repo conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,4 @@ node_modules/
 .claude/CLAUDE.md
 deploy/terraform/agentloom-dev-config
 site/
-.agentloom/checkpoints/*
-!.agentloom/checkpoints/.gitkeep
+.agentloom/

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -95,7 +95,6 @@ resource "kubernetes_secret" "provider_keys" {
 #   - kube-prometheus-stack (Prometheus + Grafana with dashboards)
 #
 # When false, the OTel SDK in agentloom degrades gracefully to no-ops.
-# -----------------------------------------------------------
 
 resource "kubernetes_namespace" "observability" {
   count = var.enable_observability ? 1 : 0

--- a/examples/05_content_moderation.yaml
+++ b/examples/05_content_moderation.yaml
@@ -24,7 +24,7 @@ state:
   response: ""
 
 steps:
-  # --- Layer 0: three checks run in parallel (no dependencies) ---
+  # Layer 0: three checks run in parallel (no dependencies)
 
   - id: check_toxicity
     type: llm_call
@@ -63,7 +63,7 @@ steps:
     prompt: "Check this content against platform policies:\n\n{state.content}"
     output: policy_result
 
-  # --- Layer 1: aggregate parallel results ---
+  # Layer 1: aggregate parallel results
 
   - id: aggregate
     type: llm_call
@@ -85,7 +85,7 @@ steps:
       Policy: {state.policy_result}
     output: decision
 
-  # --- Layer 2: route based on decision ---
+  # Layer 2: route based on decision
 
   - id: route
     type: router
@@ -97,7 +97,7 @@ steps:
         target: auto_reject
     default: send_to_review
 
-  # --- Layer 3: execute the chosen action ---
+  # Layer 3: execute the chosen action
 
   - id: publish
     type: llm_call

--- a/examples/06_lead_qualification.yaml
+++ b/examples/06_lead_qualification.yaml
@@ -26,7 +26,7 @@ state:
   outreach: ""
 
 steps:
-  # --- Layer 0: enrich + analyze in parallel ---
+  # Layer 0: enrich + analyze in parallel
 
   - id: enrich_company
     type: tool
@@ -58,7 +58,7 @@ steps:
       Message: {state.lead_message}
     output: intent_analysis
 
-  # --- Layer 1: score using both enrichment + intent ---
+  # Layer 1: score using both enrichment + intent
 
   - id: score_lead
     type: llm_call
@@ -80,7 +80,7 @@ steps:
       Intent analysis: {state.intent_analysis}
     output: lead_score
 
-  # --- Layer 2: route by score ---
+  # Layer 2: route by score
 
   - id: route
     type: router
@@ -92,7 +92,7 @@ steps:
         target: nurture_sequence
     default: log_and_archive
 
-  # --- Layer 3: generate appropriate response ---
+  # Layer 3: generate appropriate response
 
   - id: draft_outreach
     type: llm_call

--- a/examples/07_incident_triage.yaml
+++ b/examples/07_incident_triage.yaml
@@ -23,7 +23,7 @@ state:
   response: ""
 
 steps:
-  # --- Layer 0: fetch deployment context ---
+  # Layer 0: fetch deployment context
 
   - id: fetch_deploys
     type: tool
@@ -33,7 +33,7 @@ steps:
       method: "GET"
     output: recent_deploys
 
-  # --- Layer 1: root cause analysis ---
+  # Layer 1: root cause analysis
 
   - id: analyze
     type: llm_call
@@ -56,7 +56,7 @@ steps:
       Recent deployments: {state.recent_deploys}
     output: analysis
 
-  # --- Layer 2: classify severity ---
+  # Layer 2: classify severity
 
   - id: classify_severity
     type: llm_call
@@ -77,7 +77,7 @@ steps:
       Analysis: {state.analysis}
     output: severity
 
-  # --- Layer 3: route by severity ---
+  # Layer 3: route by severity
 
   - id: route
     type: router
@@ -89,7 +89,7 @@ steps:
         target: create_ticket
     default: add_to_backlog
 
-  # --- Layer 4: generate appropriate response ---
+  # Layer 4: generate appropriate response
 
   - id: incident_response
     type: llm_call

--- a/examples/08_contract_analysis.yaml
+++ b/examples/08_contract_analysis.yaml
@@ -50,7 +50,7 @@ state:
   summary: ""
 
 steps:
-  # --- Layer 0: extract and categorize clauses ---
+  # Layer 0: extract and categorize clauses
 
   - id: extract_clauses
     type: llm_call
@@ -66,7 +66,7 @@ steps:
     prompt: "Extract and categorize all clauses:\n\n{state.contract_text}"
     output: clauses
 
-  # --- Layer 1: risk assessment ---
+  # Layer 1: risk assessment
 
   - id: assess_risk
     type: llm_call
@@ -88,7 +88,7 @@ steps:
       {state.clauses}
     output: risk_assessment
 
-  # --- Layer 2: compare to market standards ---
+  # Layer 2: compare to market standards
 
   - id: compare_to_standards
     type: llm_call
@@ -112,7 +112,7 @@ steps:
       {state.risk_assessment}
     output: comparison
 
-  # --- Layer 3: executive summary ---
+  # Layer 3: executive summary
 
   - id: executive_summary
     type: llm_call

--- a/examples/09_fraud_detection.yaml
+++ b/examples/09_fraud_detection.yaml
@@ -31,7 +31,7 @@ state:
   response: ""
 
 steps:
-  # --- Layer 0: parallel data fetching ---
+  # Layer 0: parallel data fetching
 
   - id: fetch_order
     type: tool
@@ -49,7 +49,7 @@ steps:
       method: "GET"
     output: customer_history
 
-  # --- Layer 1: 4 parallel fraud signal checks ---
+  # Layer 1: 4 parallel fraud signal checks
 
   - id: check_velocity
     type: llm_call
@@ -136,7 +136,7 @@ steps:
       Customer: {state.customer_history}
     output: device_check
 
-  # --- Layer 2: aggregate all signals ---
+  # Layer 2: aggregate all signals
 
   - id: aggregate_signals
     type: llm_call
@@ -159,7 +159,7 @@ steps:
       Device: {state.device_check}
     output: risk_score
 
-  # --- Layer 3: route by risk level ---
+  # Layer 3: route by risk level
 
   - id: route_risk
     type: router
@@ -171,7 +171,7 @@ steps:
         target: enhanced_review
     default: approve_order
 
-  # --- Layer 4: actions ---
+  # Layer 4: actions
 
   - id: approve_order
     type: llm_call

--- a/examples/10_content_localization.yaml
+++ b/examples/10_content_localization.yaml
@@ -39,7 +39,7 @@ state:
   deployment_manifest: ""
 
 steps:
-  # --- Layer 0: fetch latest content version from CMS ---
+  # Layer 0: fetch latest content version from CMS
 
   - id: fetch_content
     type: tool
@@ -49,7 +49,7 @@ steps:
       method: "GET"
     output: cms_metadata
 
-  # --- Layer 1: 3 parallel localization subworkflows ---
+  # Layer 1: 3 parallel localization subworkflows
 
   - id: localize_es
     type: subworkflow
@@ -302,7 +302,7 @@ steps:
           output: final_content
     output: localize_ja
 
-  # --- Layer 2: cross-market quality review ---
+  # Layer 2: cross-market quality review
 
   - id: quality_review
     type: llm_call
@@ -325,7 +325,7 @@ steps:
       Japanese: {state.localize_ja}
     output: quality_report
 
-  # --- Layer 3: deployment manifest ---
+  # Layer 3: deployment manifest
 
   - id: generate_manifest
     type: llm_call

--- a/examples/11_insurance_claims.yaml
+++ b/examples/11_insurance_claims.yaml
@@ -50,7 +50,7 @@ state:
   response: ""
 
 steps:
-  # --- Layer 0: fetch additional claim context ---
+  # Layer 0: fetch additional claim context
 
   - id: fetch_claim_context
     type: tool
@@ -60,7 +60,7 @@ steps:
       method: "GET"
     output: claim_data
 
-  # --- Layer 1: extract structured fields ---
+  # Layer 1: extract structured fields
 
   - id: extract_fields
     type: llm_call
@@ -82,7 +82,7 @@ steps:
     prompt: "Extract structured fields from this claim:\n\n{state.claim_details}"
     output: extracted_fields
 
-  # --- Layer 2: three parallel validation tracks ---
+  # Layer 2: three parallel validation tracks
 
   - id: verify_coverage
     type: subworkflow
@@ -242,7 +242,7 @@ steps:
       Extracted: {state.extracted_fields}
     output: medical_review
 
-  # --- Layer 3: aggregate all validations ---
+  # Layer 3: aggregate all validations
 
   - id: aggregate_validations
     type: llm_call
@@ -265,7 +265,7 @@ steps:
       Medical: {state.medical_review}
     output: decision
 
-  # --- Layer 4: route ---
+  # Layer 4: route
 
   - id: route_decision
     type: router
@@ -277,7 +277,7 @@ steps:
         target: deny_claim
     default: assign_adjuster
 
-  # --- Layer 5: execute decision ---
+  # Layer 5: execute decision
 
   - id: auto_approve
     type: subworkflow

--- a/examples/12_log_analysis.yaml
+++ b/examples/12_log_analysis.yaml
@@ -19,7 +19,7 @@ state:
   response: ""
 
 steps:
-  # --- Layer 0: collect data via shell commands (parallel) ---
+  # Layer 0: collect data via shell commands (parallel)
 
   - id: collect_errors
     type: tool
@@ -37,7 +37,7 @@ steps:
       timeout: 10
     output: system_metrics
 
-  # --- Layer 1: correlate and analyze ---
+  # Layer 1: correlate and analyze
 
   - id: analyze
     type: llm_call
@@ -61,7 +61,7 @@ steps:
       {state.system_metrics}
     output: analysis
 
-  # --- Layer 2: classify ---
+  # Layer 2: classify
 
   - id: classify
     type: llm_call
@@ -76,7 +76,7 @@ steps:
     prompt: "Classify severity based on:\n\n{state.analysis}"
     output: severity
 
-  # --- Layer 3: route ---
+  # Layer 3: route
 
   - id: route
     type: router
@@ -88,7 +88,7 @@ steps:
         target: create_ticket
     default: log_silently
 
-  # --- Layer 4: respond ---
+  # Layer 4: respond
 
   - id: fire_alert
     type: llm_call

--- a/examples/13_report_generator.yaml
+++ b/examples/13_report_generator.yaml
@@ -20,7 +20,7 @@ state:
   report_output: ""
 
 steps:
-  # --- Layer 0: set up demo data files ---
+  # Layer 0: set up demo data files
 
   - id: setup_pipeline_data
     type: tool
@@ -129,7 +129,7 @@ steps:
         }
     output: setup_result_2
 
-  # --- Layer 1: read both files in parallel ---
+  # Layer 1: read both files in parallel
 
   - id: read_pipeline_results
     type: tool
@@ -147,7 +147,7 @@ steps:
       path: "state.sla_config_path"
     output: sla_data
 
-  # --- Layer 2: analyze SLA compliance ---
+  # Layer 2: analyze SLA compliance
 
   - id: analyze_sla
     type: llm_call
@@ -172,7 +172,7 @@ steps:
       SLA config: {state.sla_data}
     output: sla_analysis
 
-  # --- Layer 3: executive summary ---
+  # Layer 3: executive summary
 
   - id: executive_summary
     type: llm_call
@@ -194,7 +194,7 @@ steps:
       Raw data: {state.pipeline_data}
     output: executive_summary
 
-  # --- Layer 4: write report to file ---
+  # Layer 4: write report to file
 
   - id: write_report
     type: tool

--- a/examples/14_custom_tools_decorator.py
+++ b/examples/14_custom_tools_decorator.py
@@ -29,9 +29,7 @@ from agentloom.providers.gateway import ProviderGateway
 from agentloom.tools import ToolRegistry, tool
 from agentloom.tools.builtins import register_builtins
 
-# ---------------------------------------------------------------------------
 # Custom tools — defined with the @tool decorator
-# ---------------------------------------------------------------------------
 
 
 @tool(name="query_database", description="Query customer feedback from database")
@@ -118,10 +116,6 @@ async def create_ticket(title: str, body: str, priority: str = "medium") -> str:
     return json.dumps(ticket)
 
 
-# ---------------------------------------------------------------------------
-# Main — parse args, set up tools + gateway, run workflow
-# ---------------------------------------------------------------------------
-
 WORKFLOW_PATH = Path(__file__).parent / "14_custom_tools_decorator.yaml"
 
 
@@ -168,11 +162,9 @@ def _setup_gateway(provider: str) -> ProviderGateway:
 
 
 async def _main(provider: str, model: str | None) -> None:
-    # 1. Set up custom tool registry
     tool_registry = ToolRegistry()
     register_builtins(tool_registry)  # keep builtins available
 
-    # Register our custom tools
     tool_registry.register(query_database)
     tool_registry.register(send_slack_message)
     tool_registry.register(create_ticket)
@@ -182,7 +174,6 @@ async def _main(provider: str, model: str | None) -> None:
         print(f"  - {t.name}: {t.description}")
     print()
 
-    # 2. Load workflow from YAML
     workflow = WorkflowParser.from_yaml(WORKFLOW_PATH)
 
     if provider:
@@ -190,10 +181,8 @@ async def _main(provider: str, model: str | None) -> None:
     if model:
         workflow.config.model = model
 
-    # 3. Set up provider gateway
     gateway = _setup_gateway(workflow.config.provider)
 
-    # 4. Run
     state = StateManager(initial_state=dict(workflow.state))
     engine = WorkflowEngine(
         workflow=workflow,

--- a/examples/15_custom_tools_subclass.py
+++ b/examples/15_custom_tools_subclass.py
@@ -30,11 +30,8 @@ from agentloom.providers.gateway import ProviderGateway
 from agentloom.tools import BaseTool, ToolRegistry
 from agentloom.tools.builtins import register_builtins
 
-# ---------------------------------------------------------------------------
+
 # Custom tools — defined by subclassing BaseTool
-# ---------------------------------------------------------------------------
-
-
 class GeocodingTool(BaseTool):
     """Geocodes an address into coordinates and enriched location data."""
 
@@ -56,7 +53,6 @@ class GeocodingTool(BaseTool):
         "required": ["address"],
     }
 
-    # Simulated geocoding results
     _MOCK_RESULTS = {
         "default": {
             "lat": 37.7749,
@@ -192,17 +188,14 @@ class RiskScoreTool(BaseTool):
     }
 
     async def execute(self, **kwargs: Any) -> Any:
-        # Deterministic scoring algorithm (not ML, but production-realistic)
         health = kwargs.get("health_score", 50)
         nps = kwargs.get("nps_score", 5)
         trend = kwargs.get("ticket_volume_trend", "stable")
         days_renewal = kwargs.get("days_to_renewal", 365)
         champion_left = kwargs.get("champion_departed", False)
 
-        # Base risk from health score (inverted)
         risk = 100 - health
 
-        # NPS adjustment (-20 to +10)
         if nps <= 3:
             risk += 20
         elif nps <= 6:
@@ -210,21 +203,17 @@ class RiskScoreTool(BaseTool):
         elif nps >= 9:
             risk -= 10
 
-        # Ticket trend
         if trend == "increasing":
             risk += 15
         elif trend == "decreasing":
             risk -= 5
 
-        # Renewal proximity amplifier
         if days_renewal < 90:
             risk = int(risk * 1.3)
 
-        # Champion departure
         if champion_left:
             risk += 20
 
-        # Clamp and add slight variance
         risk = max(0, min(100, risk + random.randint(-3, 3)))
 
         result = {
@@ -241,10 +230,6 @@ class RiskScoreTool(BaseTool):
 
         return json.dumps(result, indent=2)
 
-
-# ---------------------------------------------------------------------------
-# Main — parse args, set up tools + gateway, run workflow
-# ---------------------------------------------------------------------------
 
 WORKFLOW_PATH = Path(__file__).parent / "15_custom_tools_subclass.yaml"
 
@@ -291,11 +276,9 @@ def _setup_gateway(provider: str) -> ProviderGateway:
 
 
 async def _main(provider: str, model: str | None) -> None:
-    # 1. Set up tool registry with custom tools
     tool_registry = ToolRegistry()
     register_builtins(tool_registry)
 
-    # Register custom tools (subclass instances)
     tool_registry.register(GeocodingTool())
     tool_registry.register(CRMLookupTool())
     tool_registry.register(RiskScoreTool())
@@ -307,7 +290,6 @@ async def _main(provider: str, model: str | None) -> None:
         print(f"    params: {schema_fields}")
     print()
 
-    # 2. Load workflow from YAML
     workflow = WorkflowParser.from_yaml(WORKFLOW_PATH)
 
     if provider:
@@ -320,7 +302,6 @@ async def _main(provider: str, model: str | None) -> None:
     print(f"Provider: {workflow.config.provider} / {workflow.config.model}")
     print("=" * 60)
 
-    # 3. Run
     gateway = _setup_gateway(workflow.config.provider)
     state = StateManager(initial_state=dict(workflow.state))
     engine = WorkflowEngine(

--- a/scripts/audit_approval_gate.py
+++ b/scripts/audit_approval_gate.py
@@ -82,11 +82,7 @@ def _contains(text: str, *needles: str) -> bool:
     return all(n in text for n in needles)
 
 
-# ────────────────────────────────────────────────────────────
 # Phase 1: Source contracts
-# ────────────────────────────────────────────────────────────
-
-
 def audit_step_type_enum() -> None:
     _header("StepType enum")
 
@@ -241,11 +237,7 @@ def audit_cli() -> None:
         _fail("Should use checkpoint.paused_step_id as decision key")
 
 
-# ────────────────────────────────────────────────────────────
 # Phase 2: Test coverage
-# ────────────────────────────────────────────────────────────
-
-
 def audit_unit_tests() -> None:
     _header("Unit tests (steps/test_approval_gate.py)")
 
@@ -339,11 +331,7 @@ def audit_cli_tests() -> None:
         _fail(f"{len(found)}/{len(cli_tests)} CLI tests found", detail)
 
 
-# ────────────────────────────────────────────────────────────
 # Phase 3: Integration artefacts
-# ────────────────────────────────────────────────────────────
-
-
 def audit_artefacts() -> None:
     _header("Integration artefacts")
 
@@ -413,11 +401,7 @@ def audit_artefacts() -> None:
         _fail("Example should demonstrate on_timeout")
 
 
-# ────────────────────────────────────────────────────────────
 # Phase 4: Runtime validation
-# ────────────────────────────────────────────────────────────
-
-
 def audit_runtime() -> None:
     _header("Runtime validation (live approval gate cycles)")
 
@@ -442,10 +426,10 @@ def audit_runtime() -> None:
     class _FakeProvider(BaseProvider):
         name = "fake"
 
-        async def complete(self, messages, model, **kwargs):  # noqa: ANN001,ANN003
+        async def complete(self, messages, model, **kwargs):
             return ProviderResponse(content="fake", model=model, provider="fake")
 
-        async def stream(self, *a, **kw):  # noqa: ANN002,ANN003
+        async def stream(self, *a, **kw):
             raise NotImplementedError
 
         def supports_model(self, model: str) -> bool:
@@ -487,7 +471,7 @@ def audit_runtime() -> None:
         with tempfile.TemporaryDirectory() as cp_dir:
             ckpt = FileCheckpointer(checkpoint_dir=Path(cp_dir))
 
-            # ── Pause at approval gate ─────────────────────────
+            # Pause at approval gate
             engine = WorkflowEngine(
                 workflow=workflow,
                 provider_gateway=_gw(),
@@ -514,7 +498,7 @@ def audit_runtime() -> None:
             else:
                 _fail("Runtime: approve should be PAUSED")
 
-            # ── Verify checkpoint ──────────────────────────────
+            # Verify checkpoint
             loaded = await ckpt.load("audit-approval")
             if loaded.status == "paused" and loaded.paused_step_id == "approve":
                 _pass("Runtime: checkpoint paused at approve")
@@ -524,7 +508,7 @@ def audit_runtime() -> None:
                     f" paused_step_id={loaded.paused_step_id}"
                 )
 
-            # ── Resume with approval ───────────────────────────
+            # Resume with approval
             data = await ckpt.load("audit-approval")
             resumed = await WorkflowEngine.from_checkpoint(
                 checkpoint_data=data,
@@ -552,7 +536,7 @@ def audit_runtime() -> None:
             else:
                 _fail("Runtime: send step missing from results")
 
-            # ── Resume with rejection ──────────────────────────
+            # Resume with rejection
             engine2 = WorkflowEngine(
                 workflow=workflow,
                 provider_gateway=_gw(),
@@ -580,7 +564,7 @@ def audit_runtime() -> None:
             else:
                 _fail(f"Runtime: decision={r3.final_state.get('decision')}")
 
-            # ── Final checkpoint status ────────────────────────
+            # Final checkpoint status
             final = await ckpt.load("audit-approval")
             if final.status == "success" and final.paused_step_id is None:
                 _pass("Runtime: final checkpoint is success, no paused_step_id")
@@ -590,11 +574,7 @@ def audit_runtime() -> None:
     anyio.run(_run_audit)
 
 
-# ────────────────────────────────────────────────────────────
 # Main
-# ────────────────────────────────────────────────────────────
-
-
 def main() -> int:
     global _verbose
 

--- a/scripts/audit_infra.py
+++ b/scripts/audit_infra.py
@@ -16,12 +16,10 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import shutil
 import subprocess
 import sys
-import textwrap
 from pathlib import Path
 
 try:
@@ -29,9 +27,7 @@ try:
 except ImportError:
     yaml = None  # type: ignore[assignment]
 
-# ────────────────────────────────────────────────────────────
 # Helpers
-# ────────────────────────────────────────────────────────────
 
 ROOT = Path(__file__).resolve().parent.parent
 DEPLOY = ROOT / "deploy"
@@ -116,10 +112,7 @@ def _run(cmd: list[str], cwd: Path | None = None, timeout: int = 60) -> tuple[in
     return r.returncode, r.stdout, r.stderr
 
 
-# ────────────────────────────────────────────────────────────
 # 1. Dockerfile
-# ────────────────────────────────────────────────────────────
-
 def audit_dockerfile() -> None:
     _header("Dockerfile")
     path = ROOT / "Dockerfile"
@@ -182,10 +175,7 @@ def audit_dockerfile() -> None:
         _pass("Base image is not alpine")
 
 
-# ────────────────────────────────────────────────────────────
 # 2. Docker Compose
-# ────────────────────────────────────────────────────────────
-
 def audit_docker_compose() -> None:
     _header("Docker Compose")
     path = DEPLOY / "docker-compose.yml"
@@ -241,10 +231,7 @@ def audit_docker_compose() -> None:
         _fail("agentloom missing OTEL_EXPORTER_OTLP_ENDPOINT")
 
 
-# ────────────────────────────────────────────────────────────
 # 3. K8s Base Manifests
-# ────────────────────────────────────────────────────────────
-
 def _check_pod_security(spec: dict, context: str) -> None:
     """Validate security context on a pod spec."""
     sc = spec.get("securityContext", {})
@@ -297,7 +284,10 @@ def _check_pod_security(spec: dict, context: str) -> None:
         if "cpu" not in limits:
             _pass(f"{context}/{c.get('name')}: no CPU limit (CFS throttling prevention)")
         else:
-            _fail(f"{context}/{c.get('name')}: CPU limit set — causes CFS throttling on I/O-bound LLM calls")
+            _fail(
+                f"{context}/{c.get('name')}: CPU limit set — "
+                "causes CFS throttling on I/O-bound LLM calls"
+            )
 
     # /tmp emptyDir volume
     volumes = spec.get("volumes", [])
@@ -402,7 +392,7 @@ def audit_k8s_base() -> None:
                 egress_ports.add(p.get("port"))
         required_ports = {53, 443, 4317}
         if required_ports.issubset(egress_ports):
-            _pass(f"NetworkPolicy allows required egress ports: DNS(53), HTTPS(443), OTel(4317)")
+            _pass("NetworkPolicy allows required egress ports: DNS(53), HTTPS(443), OTel(4317)")
         else:
             _fail(f"NetworkPolicy missing ports: {required_ports - egress_ports}")
 
@@ -417,10 +407,7 @@ def audit_k8s_base() -> None:
                 _fail(f"kustomization.yaml references {r} but file not found")
 
 
-# ────────────────────────────────────────────────────────────
 # 4. Kustomize Overlays
-# ────────────────────────────────────────────────────────────
-
 def audit_kustomize_overlays() -> None:
     _header("Kustomize Overlays")
     overlays_dir = DEPLOY / "k8s" / "overlays"
@@ -466,7 +453,8 @@ def audit_kustomize_overlays() -> None:
     if dev_kust:
         patches = dev_kust.get("patches", [])
         np_deleted = any(
-            isinstance(p, dict) and "$patch: delete" in str(p.get("patch", ""))
+            isinstance(p, dict)
+            and "$patch: delete" in str(p.get("patch", ""))
             and "NetworkPolicy" in str(p.get("target", ""))
             for p in patches
         )
@@ -487,10 +475,7 @@ def audit_kustomize_overlays() -> None:
                 _fail("production: should not use 'latest' tag")
 
 
-# ────────────────────────────────────────────────────────────
 # 5. Helm Chart
-# ────────────────────────────────────────────────────────────
-
 def audit_helm_chart() -> None:
     _header("Helm Chart")
     chart_dir = DEPLOY / "helm" / "agentloom"
@@ -556,7 +541,9 @@ def audit_helm_chart() -> None:
         if sa.get("automountServiceAccountToken") is False:
             _pass("values.yaml: serviceAccount.automountServiceAccountToken=false")
         else:
-            _fail("values.yaml: serviceAccount.automountServiceAccountToken should default to false")
+            _fail(
+                "values.yaml: serviceAccount.automountServiceAccountToken should default to false"
+            )
 
         # NetworkPolicy enabled by default
         np = values.get("networkPolicy", {})
@@ -582,9 +569,17 @@ def audit_helm_chart() -> None:
     # Required templates exist
     templates_dir = chart_dir / "templates"
     required_templates = [
-        "_helpers.tpl", "validate.yaml", "job.yaml", "cronjob.yaml",
-        "configmap.yaml", "secret.yaml", "serviceaccount.yaml",
-        "namespace.yaml", "networkpolicy.yaml", "resourcequota.yaml", "NOTES.txt",
+        "_helpers.tpl",
+        "validate.yaml",
+        "job.yaml",
+        "cronjob.yaml",
+        "configmap.yaml",
+        "secret.yaml",
+        "serviceaccount.yaml",
+        "namespace.yaml",
+        "networkpolicy.yaml",
+        "resourcequota.yaml",
+        "NOTES.txt",
     ]
     for t in required_templates:
         if _file_exists(templates_dir / t):
@@ -593,22 +588,36 @@ def audit_helm_chart() -> None:
             _fail(f"Template {t} missing")
 
     # Validate template uses fail function
-    validate = (templates_dir / "validate.yaml").read_text() if _file_exists(templates_dir / "validate.yaml") else ""
+    validate = (
+        (templates_dir / "validate.yaml").read_text()
+        if _file_exists(templates_dir / "validate.yaml")
+        else ""
+    )
     if "fail" in validate:
         _pass("validate.yaml uses fail function for input validation")
     else:
         _fail("validate.yaml should use fail for render-time validation")
 
     # _helpers.tpl has podSpec helper
-    helpers = (templates_dir / "_helpers.tpl").read_text() if _file_exists(templates_dir / "_helpers.tpl") else ""
+    helpers = (
+        (templates_dir / "_helpers.tpl").read_text()
+        if _file_exists(templates_dir / "_helpers.tpl")
+        else ""
+    )
     if "agentloom.podSpec" in helpers:
         _pass("_helpers.tpl defines shared podSpec (DRY between Job and CronJob)")
     else:
         _fail("_helpers.tpl should define agentloom.podSpec helper")
 
     # Job template uses podSpec
-    job_tpl = (templates_dir / "job.yaml").read_text() if _file_exists(templates_dir / "job.yaml") else ""
-    cj_tpl = (templates_dir / "cronjob.yaml").read_text() if _file_exists(templates_dir / "cronjob.yaml") else ""
+    job_tpl = (
+        (templates_dir / "job.yaml").read_text() if _file_exists(templates_dir / "job.yaml") else ""
+    )
+    cj_tpl = (
+        (templates_dir / "cronjob.yaml").read_text()
+        if _file_exists(templates_dir / "cronjob.yaml")
+        else ""
+    )
     if "agentloom.podSpec" in job_tpl:
         _pass("job.yaml uses shared podSpec helper")
     else:
@@ -625,10 +634,7 @@ def audit_helm_chart() -> None:
         _fail("ci/test-values.yaml missing — Helm CI validation will fail")
 
 
-# ────────────────────────────────────────────────────────────
 # 6. Terraform
-# ────────────────────────────────────────────────────────────
-
 def audit_terraform() -> None:
     _header("Terraform")
     tf_dir = DEPLOY / "terraform"
@@ -636,8 +642,13 @@ def audit_terraform() -> None:
         _fail("deploy/terraform/ not found")
         return
 
-    required_files = ["versions.tf", "variables.tf", "main.tf", "outputs.tf",
-                      "terraform.tfvars.example"]
+    required_files = [
+        "versions.tf",
+        "variables.tf",
+        "main.tf",
+        "outputs.tf",
+        "terraform.tfvars.example",
+    ]
     for f in required_files:
         if _file_exists(tf_dir / f):
             _pass(f"{f} exists")
@@ -660,7 +671,7 @@ def audit_terraform() -> None:
     main_tf = (tf_dir / "main.tf").read_text() if _file_exists(tf_dir / "main.tf") else ""
 
     # Conditional observability resources
-    if 'var.enable_observability' in main_tf:
+    if "var.enable_observability" in main_tf:
         _pass("Observability is conditional on enable_observability variable")
     else:
         _fail("main.tf should use var.enable_observability for conditional deployment")
@@ -669,7 +680,8 @@ def audit_terraform() -> None:
         "Jaeger": "helm_release" in main_tf and "jaeger" in main_tf,
         "OTel Collector": "otel_collector" in main_tf or "otel-collector" in main_tf,
         "kube-prometheus-stack": "kube_prometheus" in main_tf or "kube-prometheus-stack" in main_tf,
-        "Grafana dashboard ConfigMap": "grafana_dashboard" in main_tf or "agentloom-grafana-dashboard" in main_tf,
+        "Grafana dashboard ConfigMap": "grafana_dashboard" in main_tf
+        or "agentloom-grafana-dashboard" in main_tf,
     }
     for component, present in obs_components.items():
         if present:
@@ -725,10 +737,7 @@ def audit_terraform() -> None:
         _fail(f"Residual files in terraform/: {[f.name for f in residual]}")
 
 
-# ────────────────────────────────────────────────────────────
 # 7. ArgoCD
-# ────────────────────────────────────────────────────────────
-
 def audit_argocd() -> None:
     _header("ArgoCD")
     path = DEPLOY / "argocd" / "application.yaml"
@@ -785,10 +794,7 @@ def audit_argocd() -> None:
         _fail("Source path should be deploy/helm/agentloom")
 
 
-# ────────────────────────────────────────────────────────────
 # 8. CI/CD Workflows
-# ────────────────────────────────────────────────────────────
-
 def audit_ci_workflows() -> None:
     _header("CI/CD Workflows")
     workflows = ROOT / ".github" / "workflows"
@@ -844,7 +850,9 @@ def audit_ci_workflows() -> None:
         _fail("ci.yml should validate Helm chart")
 
     # Docker workflow
-    docker_content = (workflows / "docker.yml").read_text() if _file_exists(workflows / "docker.yml") else ""
+    docker_content = (
+        (workflows / "docker.yml").read_text() if _file_exists(workflows / "docker.yml") else ""
+    )
     if "ghcr.io" in docker_content:
         _pass("docker.yml pushes to GHCR")
     else:
@@ -856,14 +864,15 @@ def audit_ci_workflows() -> None:
         _fail("docker.yml should include smoke test")
 
 
-# ────────────────────────────────────────────────────────────
 # 9. Documentation Consistency
-# ────────────────────────────────────────────────────────────
-
 def audit_docs() -> None:
     _header("Documentation Consistency")
     readme = (ROOT / "README.md").read_text() if _file_exists(ROOT / "README.md") else ""
-    infra = (DEPLOY / "INFRASTRUCTURE.md").read_text() if _file_exists(DEPLOY / "INFRASTRUCTURE.md") else ""
+    infra = (
+        (DEPLOY / "INFRASTRUCTURE.md").read_text()
+        if _file_exists(DEPLOY / "INFRASTRUCTURE.md")
+        else ""
+    )
 
     if not readme:
         _fail("README.md not found")
@@ -901,18 +910,20 @@ def audit_docs() -> None:
             _fail(f"INFRASTRUCTURE.md should document {component}")
 
     # INFRASTRUCTURE.md documents security
-    for concept in ["runAsNonRoot", "readOnlyRootFilesystem", "seccompProfile",
-                     "NetworkPolicy", "automountServiceAccountToken"]:
+    for concept in [
+        "runAsNonRoot",
+        "readOnlyRootFilesystem",
+        "seccompProfile",
+        "NetworkPolicy",
+        "automountServiceAccountToken",
+    ]:
         if concept in infra:
             _pass(f"INFRASTRUCTURE.md documents {concept}")
         else:
             _fail(f"INFRASTRUCTURE.md should document {concept}")
 
 
-# ────────────────────────────────────────────────────────────
 # 10. Cross-Reference Integrity
-# ────────────────────────────────────────────────────────────
-
 def audit_cross_references() -> None:
     _header("Cross-Reference Integrity")
 
@@ -926,8 +937,13 @@ def audit_cross_references() -> None:
 
     if values and job_yaml:
         helm_repo = values.get("image", {}).get("repository", "")
-        k8s_image = job_yaml.get("spec", {}).get("template", {}).get("spec", {}).get(
-            "containers", [{}])[0].get("image", "")
+        k8s_image = (
+            job_yaml.get("spec", {})
+            .get("template", {})
+            .get("spec", {})
+            .get("containers", [{}])[0]
+            .get("image", "")
+        )
         if helm_repo and helm_repo in k8s_image:
             _pass(f"Image repository consistent: {helm_repo}")
         else:
@@ -938,12 +954,16 @@ def audit_cross_references() -> None:
     if values and compose:
         helm_otel = values.get("observability", {}).get("otelEndpoint", "")
         if "4317" in helm_otel:
-            _pass(f"Helm OTel endpoint uses port 4317")
+            _pass("Helm OTel endpoint uses port 4317")
         else:
-            _fail(f"Helm OTel endpoint should use port 4317")
+            _fail("Helm OTel endpoint should use port 4317")
 
     # Terraform references Helm chart
-    main_tf = (DEPLOY / "terraform" / "main.tf").read_text() if _file_exists(DEPLOY / "terraform" / "main.tf") else ""
+    main_tf = (
+        (DEPLOY / "terraform" / "main.tf").read_text()
+        if _file_exists(DEPLOY / "terraform" / "main.tf")
+        else ""
+    )
     if "helm/agentloom" in main_tf:
         _pass("Terraform references local Helm chart")
     else:
@@ -977,10 +997,7 @@ def audit_cross_references() -> None:
             _fail(f"ArgoCD source path '{path}' should be 'deploy/helm/agentloom'")
 
 
-# ────────────────────────────────────────────────────────────
 # 11. Tool-Based Validation (requires kustomize, helm, terraform)
-# ────────────────────────────────────────────────────────────
-
 def audit_kustomize_build() -> None:
     _header("Kustomize Build (tool)")
     if not _has_tool("kustomize"):
@@ -997,7 +1014,10 @@ def audit_kustomize_build() -> None:
                 # kubeconform reads from stdin — pipe kustomize output
                 r = subprocess.run(
                     ["kubeconform", "-strict", "-summary"],
-                    input=out, capture_output=True, text=True, timeout=30,
+                    input=out,
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
                 )
                 if r.returncode == 0:
                     _pass(f"kubeconform {overlay} — valid")
@@ -1024,10 +1044,18 @@ def audit_helm_render() -> None:
         _fail("helm lint — failed", err or out)
 
     # Template render
-    rc, out, err = _run([
-        "helm", "template", "test", str(chart),
-        "-f", str(ci_values), "-n", "agentloom",
-    ])
+    rc, out, err = _run(
+        [
+            "helm",
+            "template",
+            "test",
+            str(chart),
+            "-f",
+            str(ci_values),
+            "-n",
+            "agentloom",
+        ]
+    )
     if rc == 0:
         _pass("helm template — renders successfully")
 
@@ -1035,7 +1063,10 @@ def audit_helm_render() -> None:
         if _has_tool("kubeconform"):
             r = subprocess.run(
                 ["kubeconform", "-strict", "-summary"],
-                input=out, capture_output=True, text=True, timeout=30,
+                input=out,
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
             if r.returncode == 0:
                 _pass("kubeconform on Helm output — valid")
@@ -1045,9 +1076,16 @@ def audit_helm_render() -> None:
         _fail("helm template — failed", err)
 
     # Validation: missing workflow definition should fail
-    rc, out, err = _run([
-        "helm", "template", "test", str(chart), "-n", "agentloom",
-    ])
+    rc, out, err = _run(
+        [
+            "helm",
+            "template",
+            "test",
+            str(chart),
+            "-n",
+            "agentloom",
+        ]
+    )
     if rc != 0 and "workflow" in (err + out).lower():
         _pass("helm template without workflow.definition — fails with clear message")
     elif rc != 0:
@@ -1089,10 +1127,7 @@ def audit_terraform_validate() -> None:
         _fail("terraform fmt — formatting issues", out)
 
 
-# ────────────────────────────────────────────────────────────
 # Main
-# ────────────────────────────────────────────────────────────
-
 def main() -> int:
     global _verbose
 
@@ -1126,10 +1161,12 @@ def main() -> int:
     # Summary
     total = _pass_count + _fail_count + _skip_count
     print(f"\n{'=' * 60}")
-    print(f"  {_bold('Results')}: {_green(f'{_pass_count} passed')}  "
-          f"{_red(f'{_fail_count} failed') if _fail_count else f'{_fail_count} failed'}  "
-          f"{_yellow(f'{_skip_count} skipped') if _skip_count else f'{_skip_count} skipped'}  "
-          f"({total} total)")
+    print(
+        f"  {_bold('Results')}: {_green(f'{_pass_count} passed')}  "
+        f"{_red(f'{_fail_count} failed') if _fail_count else f'{_fail_count} failed'}  "
+        f"{_yellow(f'{_skip_count} skipped') if _skip_count else f'{_skip_count} skipped'}  "
+        f"({total} total)"
+    )
     print(f"{'=' * 60}\n")
 
     return 1 if _fail_count > 0 else 0

--- a/scripts/audit_integration.py
+++ b/scripts/audit_integration.py
@@ -40,35 +40,42 @@ _verbose = False
 _phase_results: dict[str, tuple[int, int, int]] = {}
 
 
-# ── Output helpers ──────────────────────────────────────────
-
+# Output helpers
 def _green(t: str) -> str:
     return f"\033[92m{t}\033[0m"
+
 
 def _red(t: str) -> str:
     return f"\033[91m{t}\033[0m"
 
+
 def _yellow(t: str) -> str:
     return f"\033[93m{t}\033[0m"
+
 
 def _cyan(t: str) -> str:
     return f"\033[96m{t}\033[0m"
 
+
 def _bold(t: str) -> str:
     return f"\033[1m{t}\033[0m"
+
 
 def _header(title: str) -> None:
     print(f"\n{'━' * 64}")
     print(f"  {_bold(title)}")
     print(f"{'━' * 64}")
 
+
 def _step(msg: str) -> None:
     print(f"\n  {_cyan('▶')} {msg}")
+
 
 def _pass(msg: str) -> None:
     global _pass_count
     _pass_count += 1
     print(f"  {_green('✓')} {msg}")
+
 
 def _fail(msg: str, detail: str = "") -> None:
     global _fail_count
@@ -78,18 +85,19 @@ def _fail(msg: str, detail: str = "") -> None:
         for line in detail.strip().splitlines()[:15]:
             print(f"      {line}")
 
+
 def _skip(msg: str) -> None:
     global _skip_count
     _skip_count += 1
     print(f"  {_yellow('○')} {msg}")
+
 
 def _info(msg: str) -> None:
     if _verbose:
         print(f"    {msg}")
 
 
-# ── Subprocess helpers ──────────────────────────────────────
-
+# Subprocess helpers
 def _run(
     cmd: list[str],
     cwd: Path | None = None,
@@ -102,8 +110,12 @@ def _run(
     if _verbose:
         print(f"    $ {' '.join(cmd)}")
     r = subprocess.run(
-        cmd, capture_output=capture, text=True,
-        cwd=cwd, timeout=timeout, env=run_env,
+        cmd,
+        capture_output=capture,
+        text=True,
+        cwd=cwd,
+        timeout=timeout,
+        env=run_env,
     )
     return r.returncode, r.stdout, r.stderr
 
@@ -138,19 +150,16 @@ def _save_phase(name: str) -> None:
     _phase_results[name] = (_pass_count, _fail_count, _skip_count)
 
 
-# ────────────────────────────────────────────────────────────
 # Phase 1: Docker
-# ────────────────────────────────────────────────────────────
-
 def phase_docker() -> None:
     _header("Phase 1: Docker Build & Smoke Test")
-    p0, f0, s0 = _pass_count, _fail_count, _skip_count
 
     # Build image
     _step("Building Docker image (agentloom:audit-int)")
     rc, out, err = _run(
         ["docker", "build", "-t", "agentloom:audit-int", "."],
-        cwd=ROOT, timeout=300,
+        cwd=ROOT,
+        timeout=300,
     )
     if rc == 0:
         _pass("Docker build succeeded")
@@ -162,9 +171,17 @@ def phase_docker() -> None:
     # Build with observability
     _step("Building Docker image with observability extras")
     rc, out, err = _run(
-        ["docker", "build", "--build-arg", "BUILD_OBSERVABILITY=true",
-         "-t", "agentloom:audit-int-obs", "."],
-        cwd=ROOT, timeout=300,
+        [
+            "docker",
+            "build",
+            "--build-arg",
+            "BUILD_OBSERVABILITY=true",
+            "-t",
+            "agentloom:audit-int-obs",
+            ".",
+        ],
+        cwd=ROOT,
+        timeout=300,
     )
     if rc == 0:
         _pass("Docker build (observability) succeeded")
@@ -181,11 +198,18 @@ def phase_docker() -> None:
 
     # Smoke test: validate workflow
     _step("Validating example workflow inside container")
-    rc, out, err = _run([
-        "docker", "run", "--rm",
-        "-v", f"{ROOT}/examples:/workflows:ro",
-        "agentloom:audit-int", "validate", "/workflows/01_simple_qa.yaml",
-    ])
+    rc, out, err = _run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{ROOT}/examples:/workflows:ro",
+            "agentloom:audit-int",
+            "validate",
+            "/workflows/01_simple_qa.yaml",
+        ]
+    )
     if rc == 0:
         _pass("Workflow validation passed inside container")
     else:
@@ -193,10 +217,16 @@ def phase_docker() -> None:
 
     # Verify non-root
     _step("Checking container runs as non-root")
-    rc, out, err = _run([
-        "docker", "run", "--rm", "--entrypoint", "id",
-        "agentloom:audit-int",
-    ])
+    rc, out, err = _run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--entrypoint",
+            "id",
+            "agentloom:audit-int",
+        ]
+    )
     if rc == 0 and "1000" in out:
         _pass(f"Container runs as UID 1000: {out.strip()}")
     else:
@@ -204,13 +234,21 @@ def phase_docker() -> None:
 
     # Verify read-only filesystem
     _step("Checking read-only root filesystem")
-    rc, out, err = _run([
-        "docker", "run", "--rm", "--read-only",
-        "--tmpfs", "/tmp",
-        "--entrypoint", "sh",
-        "agentloom:audit-int", "-c",
-        "touch /test-readonly 2>&1 || echo READONLY_OK",
-    ])
+    rc, out, err = _run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--read-only",
+            "--tmpfs",
+            "/tmp",
+            "--entrypoint",
+            "sh",
+            "agentloom:audit-int",
+            "-c",
+            "touch /test-readonly 2>&1 || echo READONLY_OK",
+        ]
+    )
     if "READONLY_OK" in out or "Read-only" in out or "read-only" in err:
         _pass("Read-only root filesystem works")
     else:
@@ -218,10 +256,16 @@ def phase_docker() -> None:
 
     # Image size
     _step("Checking image size")
-    rc, out, err = _run([
-        "docker", "image", "inspect", "agentloom:audit-int",
-        "--format", "{{.Size}}",
-    ])
+    rc, out, err = _run(
+        [
+            "docker",
+            "image",
+            "inspect",
+            "agentloom:audit-int",
+            "--format",
+            "{{.Size}}",
+        ]
+    )
     if rc == 0:
         size_mb = int(out.strip()) / (1024 * 1024)
         if size_mb < 350:
@@ -232,18 +276,15 @@ def phase_docker() -> None:
     _save_phase("Docker")
 
 
-# ────────────────────────────────────────────────────────────
 # Phase 2: Docker Compose
-# ────────────────────────────────────────────────────────────
-
 def phase_docker_compose() -> None:
     _header("Phase 2: Docker Compose — Observability Stack")
-    p0, f0, s0 = _pass_count, _fail_count, _skip_count
 
     _step("Starting observability stack (docker compose up -d)")
     rc, out, err = _run(
         ["docker", "compose", "up", "-d"],
-        cwd=DEPLOY, timeout=120,
+        cwd=DEPLOY,
+        timeout=120,
     )
     if rc != 0:
         _fail("docker compose up failed", err[-500:])
@@ -270,16 +311,40 @@ def phase_docker_compose() -> None:
         _step("Checking service endpoints")
 
         # Jaeger
-        rc, out, err = _run(["docker", "compose", "exec", "-T", "jaeger",
-                             "wget", "--spider", "-q", "http://localhost:16686/"], cwd=DEPLOY)
+        rc, out, err = _run(
+            [
+                "docker",
+                "compose",
+                "exec",
+                "-T",
+                "jaeger",
+                "wget",
+                "--spider",
+                "-q",
+                "http://localhost:16686/",
+            ],
+            cwd=DEPLOY,
+        )
         if rc == 0:
             _pass("Jaeger UI is accessible (port 16686)")
         else:
             _fail("Jaeger UI not accessible")
 
         # Prometheus
-        rc, out, err = _run(["docker", "compose", "exec", "-T", "prometheus",
-                             "wget", "--spider", "-q", "http://localhost:9090/-/healthy"], cwd=DEPLOY)
+        rc, out, err = _run(
+            [
+                "docker",
+                "compose",
+                "exec",
+                "-T",
+                "prometheus",
+                "wget",
+                "--spider",
+                "-q",
+                "http://localhost:9090/-/healthy",
+            ],
+            cwd=DEPLOY,
+        )
         if rc == 0:
             _pass("Prometheus is healthy (port 9090)")
         else:
@@ -287,9 +352,21 @@ def phase_docker_compose() -> None:
 
         # Grafana — depends on renderer + prometheus, may need extra time
         grafana_ok = False
-        for attempt in range(6):
-            rc, out, err = _run(["docker", "compose", "exec", "-T", "grafana",
-                                 "wget", "--spider", "-q", "http://localhost:3000/api/health"], cwd=DEPLOY)
+        for _attempt in range(6):
+            rc, out, err = _run(
+                [
+                    "docker",
+                    "compose",
+                    "exec",
+                    "-T",
+                    "grafana",
+                    "wget",
+                    "--spider",
+                    "-q",
+                    "http://localhost:3000/api/health",
+                ],
+                cwd=DEPLOY,
+            )
             if rc == 0:
                 grafana_ok = True
                 break
@@ -308,10 +385,19 @@ def phase_docker_compose() -> None:
 
         # Validate workflow inside compose network
         _step("Running agentloom validate inside compose network")
-        rc, out, err = _run([
-            "docker", "compose", "run", "--rm", "agentloom",
-            "validate", "/workflows/01_simple_qa.yaml",
-        ], cwd=DEPLOY, timeout=60)
+        rc, out, err = _run(
+            [
+                "docker",
+                "compose",
+                "run",
+                "--rm",
+                "agentloom",
+                "validate",
+                "/workflows/01_simple_qa.yaml",
+            ],
+            cwd=DEPLOY,
+            timeout=60,
+        )
         if rc == 0:
             _pass("agentloom validate works in compose environment")
         else:
@@ -326,10 +412,7 @@ def phase_docker_compose() -> None:
     _save_phase("Docker Compose")
 
 
-# ────────────────────────────────────────────────────────────
 # Phase 3: Kustomize + Kind
-# ────────────────────────────────────────────────────────────
-
 def phase_kustomize() -> None:
     _header("Phase 3: Kustomize — Kind Cluster + Dev Overlay")
     cluster_name = "audit-kustomize"
@@ -345,10 +428,17 @@ def phase_kustomize() -> None:
     try:
         # Load local image
         _step("Loading agentloom:audit-int into kind cluster")
-        rc, out, err = _run([
-            "kind", "load", "docker-image", "agentloom:audit-int",
-            "--name", cluster_name,
-        ], timeout=120)
+        rc, out, err = _run(
+            [
+                "kind",
+                "load",
+                "docker-image",
+                "agentloom:audit-int",
+                "--name",
+                cluster_name,
+            ],
+            timeout=120,
+        )
         if rc == 0:
             _pass("Image loaded into kind cluster")
         else:
@@ -357,10 +447,13 @@ def phase_kustomize() -> None:
         # Build kustomize for all overlays
         for overlay in ["dev", "staging", "production"]:
             _step(f"Building kustomize overlay: {overlay}")
-            rc, out, err = _run([
-                "kustomize", "build",
-                str(DEPLOY / "k8s" / "overlays" / overlay),
-            ])
+            rc, out, err = _run(
+                [
+                    "kustomize",
+                    "build",
+                    str(DEPLOY / "k8s" / "overlays" / overlay),
+                ]
+            )
             if rc == 0:
                 _pass(f"kustomize build {overlay} — OK")
             else:
@@ -368,10 +461,13 @@ def phase_kustomize() -> None:
 
         # Apply dev overlay (with image override)
         _step("Applying dev overlay to cluster")
-        rc, kust_out, err = _run([
-            "kustomize", "build",
-            str(DEPLOY / "k8s" / "overlays" / "dev"),
-        ])
+        rc, kust_out, err = _run(
+            [
+                "kustomize",
+                "build",
+                str(DEPLOY / "k8s" / "overlays" / "dev"),
+            ]
+        )
         if rc != 0:
             _fail("kustomize build dev failed", err)
             return
@@ -385,7 +481,10 @@ def phase_kustomize() -> None:
         # Apply
         r = subprocess.run(
             ["kubectl", "apply", "-f", "-"],
-            input=kust_out, capture_output=True, text=True, timeout=30,
+            input=kust_out,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if r.returncode == 0:
             _pass("Dev overlay applied to cluster")
@@ -395,88 +494,116 @@ def phase_kustomize() -> None:
 
         # Patch configmap with a validate-only workflow
         _step("Patching configmap with validate workflow")
-        rc, out, err = _run([
-            "kubectl", "patch", "configmap", "agentloom-workflows",
-            "-n", "agentloom", "--type", "merge",
-            "-p", json.dumps({"data": {"workflow.yaml": (
-                "name: audit-test\n"
-                "version: '1.0'\n"
-                "config:\n"
-                "  provider: ollama\n"
-                "  model: phi4\n"
-                "state:\n"
-                "  question: test\n"
-                "steps:\n"
-                "  - id: hello\n"
-                "    type: llm_call\n"
-                "    prompt: 'say hello'\n"
-                "    output: answer\n"
-            )}}),
-        ])
+        rc, out, err = _run(
+            [
+                "kubectl",
+                "patch",
+                "configmap",
+                "agentloom-workflows",
+                "-n",
+                "agentloom",
+                "--type",
+                "merge",
+                "-p",
+                json.dumps(
+                    {
+                        "data": {
+                            "workflow.yaml": (
+                                "name: audit-test\n"
+                                "version: '1.0'\n"
+                                "config:\n"
+                                "  provider: ollama\n"
+                                "  model: phi4\n"
+                                "state:\n"
+                                "  question: test\n"
+                                "steps:\n"
+                                "  - id: hello\n"
+                                "    type: llm_call\n"
+                                "    prompt: 'say hello'\n"
+                                "    output: answer\n"
+                            )
+                        }
+                    }
+                ),
+            ]
+        )
         if rc == 0:
             _pass("ConfigMap patched")
 
         # Delete original job and recreate with validate args (Jobs are immutable)
         _step("Recreating job with 'validate' args (Jobs are immutable)")
-        _run(["kubectl", "delete", "job", "agentloom-workflow", "-n", "agentloom",
-              "--wait=true"], timeout=30)
+        _run(
+            ["kubectl", "delete", "job", "agentloom-workflow", "-n", "agentloom", "--wait=true"],
+            timeout=30,
+        )
         time.sleep(3)
 
         # Create a minimal validate-only job directly
-        validate_job = json.dumps({
-            "apiVersion": "batch/v1",
-            "kind": "Job",
-            "metadata": {
-                "name": "agentloom-workflow",
-                "namespace": "agentloom",
-                "labels": {"app.kubernetes.io/name": "agentloom"},
-            },
-            "spec": {
-                "backoffLimit": 0,
-                "ttlSecondsAfterFinished": 60,
-                "template": {
-                    "metadata": {"labels": {"app.kubernetes.io/name": "agentloom"}},
-                    "spec": {
-                        "restartPolicy": "Never",
-                        "serviceAccountName": "agentloom",
-                        "automountServiceAccountToken": False,
-                        "securityContext": {
-                            "runAsNonRoot": True,
-                            "runAsUser": 1000,
-                            "runAsGroup": 1000,
-                            "fsGroup": 1000,
-                            "seccompProfile": {"type": "RuntimeDefault"},
-                        },
-                        "containers": [{
-                            "name": "agentloom",
-                            "image": "agentloom:audit-int",
-                            "imagePullPolicy": "IfNotPresent",
-                            "args": ["validate", "/workflows/workflow.yaml"],
+        validate_job = json.dumps(
+            {
+                "apiVersion": "batch/v1",
+                "kind": "Job",
+                "metadata": {
+                    "name": "agentloom-workflow",
+                    "namespace": "agentloom",
+                    "labels": {"app.kubernetes.io/name": "agentloom"},
+                },
+                "spec": {
+                    "backoffLimit": 0,
+                    "ttlSecondsAfterFinished": 60,
+                    "template": {
+                        "metadata": {"labels": {"app.kubernetes.io/name": "agentloom"}},
+                        "spec": {
+                            "restartPolicy": "Never",
+                            "serviceAccountName": "agentloom",
+                            "automountServiceAccountToken": False,
                             "securityContext": {
-                                "allowPrivilegeEscalation": False,
-                                "readOnlyRootFilesystem": True,
-                                "capabilities": {"drop": ["ALL"]},
+                                "runAsNonRoot": True,
+                                "runAsUser": 1000,
+                                "runAsGroup": 1000,
+                                "fsGroup": 1000,
+                                "seccompProfile": {"type": "RuntimeDefault"},
                             },
-                            "resources": {
-                                "requests": {"memory": "64Mi", "cpu": "50m"},
-                                "limits": {"memory": "128Mi"},
-                            },
-                            "volumeMounts": [
-                                {"name": "workflows", "mountPath": "/workflows", "readOnly": True},
-                                {"name": "tmp", "mountPath": "/tmp"},
+                            "containers": [
+                                {
+                                    "name": "agentloom",
+                                    "image": "agentloom:audit-int",
+                                    "imagePullPolicy": "IfNotPresent",
+                                    "args": ["validate", "/workflows/workflow.yaml"],
+                                    "securityContext": {
+                                        "allowPrivilegeEscalation": False,
+                                        "readOnlyRootFilesystem": True,
+                                        "capabilities": {"drop": ["ALL"]},
+                                    },
+                                    "resources": {
+                                        "requests": {"memory": "64Mi", "cpu": "50m"},
+                                        "limits": {"memory": "128Mi"},
+                                    },
+                                    "volumeMounts": [
+                                        {
+                                            "name": "workflows",
+                                            "mountPath": "/workflows",
+                                            "readOnly": True,
+                                        },
+                                        {"name": "tmp", "mountPath": "/tmp"},
+                                    ],
+                                }
                             ],
-                        }],
-                        "volumes": [
-                            {"name": "workflows", "configMap": {"name": "agentloom-workflows"}},
-                            {"name": "tmp", "emptyDir": {}},
-                        ],
+                            "volumes": [
+                                {"name": "workflows", "configMap": {"name": "agentloom-workflows"}},
+                                {"name": "tmp", "emptyDir": {}},
+                            ],
+                        },
                     },
                 },
-            },
-        })
+            }
+        )
         r = subprocess.run(
             ["kubectl", "apply", "-f", "-"],
-            input=validate_job, capture_output=True, text=True, timeout=30,
+            input=validate_job,
+            capture_output=True,
+            text=True,
+            timeout=30,
         )
         if r.returncode == 0:
             _pass("Job recreated with validate args")
@@ -486,9 +613,17 @@ def phase_kustomize() -> None:
 
         # Wait for pod to be created first
         pod_created = _wait_for(
-            ["kubectl", "get", "pods", "-n", "agentloom",
-             "-l", "app.kubernetes.io/name=agentloom",
-             "-o", "jsonpath={.items[0].status.phase}"],
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "-n",
+                "agentloom",
+                "-l",
+                "app.kubernetes.io/name=agentloom",
+                "-o",
+                "jsonpath={.items[0].status.phase}",
+            ],
             lambda out, err: out.strip() != "",
             "pod to be created",
             timeout=60,
@@ -496,31 +631,60 @@ def phase_kustomize() -> None:
         )
         if not pod_created:
             _info("Pod not created — checking events for diagnosis")
-            rc, events, _ = _run([
-                "kubectl", "get", "events", "-n", "agentloom",
-                "--sort-by=.lastTimestamp",
-            ])
+            rc, events, _ = _run(
+                [
+                    "kubectl",
+                    "get",
+                    "events",
+                    "-n",
+                    "agentloom",
+                    "--sort-by=.lastTimestamp",
+                ]
+            )
             _info(f"Events:\n{events[-800:]}")
-            rc, desc, _ = _run([
-                "kubectl", "describe", "job", "agentloom-workflow", "-n", "agentloom",
-            ])
+            rc, desc, _ = _run(
+                [
+                    "kubectl",
+                    "describe",
+                    "job",
+                    "agentloom-workflow",
+                    "-n",
+                    "agentloom",
+                ]
+            )
             _info(f"Job describe:\n{desc[-800:]}")
 
         # Verify security context is enforced (check before job finishes)
         _step("Verifying pod security context")
-        rc, out, err = _run([
-            "kubectl", "get", "pod", "-n", "agentloom",
-            "-l", "app.kubernetes.io/name=agentloom",
-            "-o", "jsonpath={.items[0].spec.securityContext.runAsNonRoot}",
-        ])
+        rc, out, err = _run(
+            [
+                "kubectl",
+                "get",
+                "pod",
+                "-n",
+                "agentloom",
+                "-l",
+                "app.kubernetes.io/name=agentloom",
+                "-o",
+                "jsonpath={.items[0].spec.securityContext.runAsNonRoot}",
+            ]
+        )
         if "true" in out:
             _pass("Pod runs as non-root (enforced by PSS)")
         else:
             # Pod might not exist yet — check directly from job spec
-            rc2, out2, _ = _run([
-                "kubectl", "get", "job", "agentloom-workflow", "-n", "agentloom",
-                "-o", "jsonpath={.spec.template.spec.securityContext.runAsNonRoot}",
-            ])
+            rc2, out2, _ = _run(
+                [
+                    "kubectl",
+                    "get",
+                    "job",
+                    "agentloom-workflow",
+                    "-n",
+                    "agentloom",
+                    "-o",
+                    "jsonpath={.spec.template.spec.securityContext.runAsNonRoot}",
+                ]
+            )
             if "true" in out2:
                 _pass("Job spec has runAsNonRoot=true (pod may not be scheduled yet)")
             else:
@@ -528,44 +692,86 @@ def phase_kustomize() -> None:
 
         # Wait for job completion (check succeeded/failed counts, not conditions)
         job_done = _wait_for(
-            ["kubectl", "get", "job", "agentloom-workflow", "-n", "agentloom",
-             "-o", "jsonpath={.status.succeeded},{.status.failed}"],
+            [
+                "kubectl",
+                "get",
+                "job",
+                "agentloom-workflow",
+                "-n",
+                "agentloom",
+                "-o",
+                "jsonpath={.status.succeeded},{.status.failed}",
+            ],
             lambda out, err: "1" in out,
             "job to complete",
             timeout=120,
             interval=5,
         )
         if job_done:
-            rc, status, err = _run([
-                "kubectl", "get", "job", "agentloom-workflow", "-n", "agentloom",
-                "-o", "jsonpath=succeeded={.status.succeeded} failed={.status.failed}",
-            ])
+            rc, status, err = _run(
+                [
+                    "kubectl",
+                    "get",
+                    "job",
+                    "agentloom-workflow",
+                    "-n",
+                    "agentloom",
+                    "-o",
+                    "jsonpath=succeeded={.status.succeeded} failed={.status.failed}",
+                ]
+            )
             if "succeeded=1" in status:
                 _pass(f"Job completed successfully ({status.strip()})")
             elif "failed=" in status and "failed=<" not in status:
                 _fail(f"Job failed: {status}")
-                rc2, logs, _ = _run([
-                    "kubectl", "logs", "job/agentloom-workflow", "-n", "agentloom",
-                ])
+                rc2, logs, _ = _run(
+                    [
+                        "kubectl",
+                        "logs",
+                        "job/agentloom-workflow",
+                        "-n",
+                        "agentloom",
+                    ]
+                )
                 _info(f"Job logs:\n{logs[:500]}")
             else:
                 _pass(f"Job finished ({status.strip()})")
         else:
             _fail("Job did not complete within timeout")
-            rc2, pods, _ = _run([
-                "kubectl", "get", "pods", "-n", "agentloom", "--no-headers",
-            ])
+            rc2, pods, _ = _run(
+                [
+                    "kubectl",
+                    "get",
+                    "pods",
+                    "-n",
+                    "agentloom",
+                    "--no-headers",
+                ]
+            )
             _info(f"Pods:\n{pods}")
-            rc3, desc, _ = _run([
-                "kubectl", "describe", "job", "agentloom-workflow", "-n", "agentloom",
-            ])
+            rc3, desc, _ = _run(
+                [
+                    "kubectl",
+                    "describe",
+                    "job",
+                    "agentloom-workflow",
+                    "-n",
+                    "agentloom",
+                ]
+            )
             _info(f"Job describe (tail):\n{desc[-500:]}")
 
         # Verify namespace PSS labels
-        rc, out, err = _run([
-            "kubectl", "get", "ns", "agentloom",
-            "-o", "jsonpath={.metadata.labels.pod-security\\.kubernetes\\.io/enforce}",
-        ])
+        rc, out, err = _run(
+            [
+                "kubectl",
+                "get",
+                "ns",
+                "agentloom",
+                "-o",
+                "jsonpath={.metadata.labels.pod-security\\.kubernetes\\.io/enforce}",
+            ]
+        )
         if "restricted" in out:
             _pass("Namespace has PSS enforce=restricted label")
         else:
@@ -580,10 +786,7 @@ def phase_kustomize() -> None:
     _save_phase("Kustomize")
 
 
-# ────────────────────────────────────────────────────────────
 # Phase 4: Terraform — Full Stack with Observability
-# ────────────────────────────────────────────────────────────
-
 def phase_terraform() -> None:
     _header("Phase 4: Terraform — Full Stack (Kind + Observability + AgentLoom)")
     tf_dir = DEPLOY / "terraform"
@@ -601,12 +804,18 @@ def phase_terraform() -> None:
 
     # Plan
     _step("terraform plan")
-    rc, out, err = _run([
-        "terraform", "plan", "-input=false",
-        f"-var=cluster_name={cluster_name}",
-        "-var=enable_observability=true",
-        "-var=agentloom_image_tag=audit-int",
-    ], cwd=tf_dir, timeout=120)
+    rc, out, err = _run(
+        [
+            "terraform",
+            "plan",
+            "-input=false",
+            f"-var=cluster_name={cluster_name}",
+            "-var=enable_observability=true",
+            "-var=agentloom_image_tag=audit-int",
+        ],
+        cwd=tf_dir,
+        timeout=120,
+    )
     if rc == 0:
         _pass("terraform plan succeeded")
         # Check plan includes observability resources
@@ -623,22 +832,36 @@ def phase_terraform() -> None:
 
     # Apply
     _step("terraform apply (this may take 3-5 minutes)")
-    rc, out, err = _run([
-        "terraform", "apply", "-auto-approve", "-input=false",
-        f"-var=cluster_name={cluster_name}",
-        "-var=enable_observability=true",
-        "-var=agentloom_image_tag=audit-int",
-    ], cwd=tf_dir, timeout=600)
+    rc, out, err = _run(
+        [
+            "terraform",
+            "apply",
+            "-auto-approve",
+            "-input=false",
+            f"-var=cluster_name={cluster_name}",
+            "-var=enable_observability=true",
+            "-var=agentloom_image_tag=audit-int",
+        ],
+        cwd=tf_dir,
+        timeout=600,
+    )
     if rc != 0:
         _fail("terraform apply failed", err[-800:] if err else out[-800:])
         # Try cleanup
         _step("Attempting terraform destroy after failure")
-        _run([
-            "terraform", "destroy", "-auto-approve", "-input=false",
-            f"-var=cluster_name={cluster_name}",
-            "-var=enable_observability=true",
-            "-var=agentloom_image_tag=audit-int",
-        ], cwd=tf_dir, timeout=300)
+        _run(
+            [
+                "terraform",
+                "destroy",
+                "-auto-approve",
+                "-input=false",
+                f"-var=cluster_name={cluster_name}",
+                "-var=enable_observability=true",
+                "-var=agentloom_image_tag=audit-int",
+            ],
+            cwd=tf_dir,
+            timeout=300,
+        )
         _run(["kind", "delete", "cluster", "--name", cluster_name], timeout=60)
         _save_phase("Terraform")
         return
@@ -656,7 +879,7 @@ def phase_terraform() -> None:
         kubeconfig = kubeconfig.strip()
         kenv = {"KUBECONFIG": kubeconfig}
 
-        # ── Verify Kind cluster ──
+        # Verify Kind cluster
         _step("Verifying kind cluster")
         rc, out, err = _run(["kubectl", "cluster-info"], env=kenv)
         if rc == 0 and "running" in out.lower():
@@ -665,7 +888,7 @@ def phase_terraform() -> None:
             _fail("Kind cluster not reachable", err or out)
             return
 
-        # ── Verify namespaces ──
+        # Verify namespaces
         _step("Verifying namespaces")
         rc, out, err = _run(["kubectl", "get", "ns", "-o", "name"], env=kenv)
         if "namespace/agentloom" in out:
@@ -677,27 +900,44 @@ def phase_terraform() -> None:
         else:
             _fail("Namespace 'observability' missing")
 
-        # ── Verify agentloom namespace PSS labels ──
-        rc, out, err = _run([
-            "kubectl", "get", "ns", "agentloom",
-            "-o", "jsonpath={.metadata.labels.pod-security\\.kubernetes\\.io/enforce}",
-        ], env=kenv)
+        # Verify agentloom namespace PSS labels
+        rc, out, err = _run(
+            [
+                "kubectl",
+                "get",
+                "ns",
+                "agentloom",
+                "-o",
+                "jsonpath={.metadata.labels.pod-security\\.kubernetes\\.io/enforce}",
+            ],
+            env=kenv,
+        )
         if "restricted" in out:
             _pass("agentloom namespace has PSS enforce=restricted")
         else:
             _fail(f"agentloom namespace PSS label: '{out}'")
 
-        # ── Verify observability pods ──
+        # Verify observability pods
         _step("Waiting for observability pods to be ready")
 
         # Jaeger
         jaeger_ready = _wait_for(
-            ["kubectl", "get", "pods", "-n", "observability",
-             "-l", "app.kubernetes.io/name=jaeger",
-             "-o", "jsonpath={.items[*].status.phase}"],
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "-n",
+                "observability",
+                "-l",
+                "app.kubernetes.io/name=jaeger",
+                "-o",
+                "jsonpath={.items[*].status.phase}",
+            ],
             lambda out, err: "Running" in out,
             "Jaeger pod",
-            timeout=180, interval=10, env=kenv,
+            timeout=180,
+            interval=10,
+            env=kenv,
         )
         if jaeger_ready:
             _pass("Jaeger pod is Running")
@@ -708,12 +948,22 @@ def phase_terraform() -> None:
 
         # OTel Collector
         otel_ready = _wait_for(
-            ["kubectl", "get", "pods", "-n", "observability",
-             "-l", "app.kubernetes.io/name=opentelemetry-collector",
-             "-o", "jsonpath={.items[*].status.phase}"],
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "-n",
+                "observability",
+                "-l",
+                "app.kubernetes.io/name=opentelemetry-collector",
+                "-o",
+                "jsonpath={.items[*].status.phase}",
+            ],
             lambda out, err: "Running" in out,
             "OTel Collector pod",
-            timeout=120, interval=10, env=kenv,
+            timeout=120,
+            interval=10,
+            env=kenv,
         )
         if otel_ready:
             _pass("OTel Collector pod is Running")
@@ -722,22 +972,42 @@ def phase_terraform() -> None:
 
         # Prometheus
         prom_ready = _wait_for(
-            ["kubectl", "get", "pods", "-n", "observability",
-             "-l", "app=kube-prometheus-stack-prometheus",
-             "-o", "jsonpath={.items[*].status.phase}"],
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "-n",
+                "observability",
+                "-l",
+                "app=kube-prometheus-stack-prometheus",
+                "-o",
+                "jsonpath={.items[*].status.phase}",
+            ],
             lambda out, err: "Running" in out,
             "Prometheus pod",
-            timeout=180, interval=10, env=kenv,
+            timeout=180,
+            interval=10,
+            env=kenv,
         )
         if not prom_ready:
             # Try alternative label
             prom_ready = _wait_for(
-                ["kubectl", "get", "pods", "-n", "observability",
-                 "-l", "app.kubernetes.io/name=prometheus",
-                 "-o", "jsonpath={.items[*].status.phase}"],
+                [
+                    "kubectl",
+                    "get",
+                    "pods",
+                    "-n",
+                    "observability",
+                    "-l",
+                    "app.kubernetes.io/name=prometheus",
+                    "-o",
+                    "jsonpath={.items[*].status.phase}",
+                ],
                 lambda out, err: "Running" in out,
                 "Prometheus pod (alt label)",
-                timeout=60, interval=10, env=kenv,
+                timeout=60,
+                interval=10,
+                env=kenv,
             )
         if prom_ready:
             _pass("Prometheus pod is Running")
@@ -748,49 +1018,83 @@ def phase_terraform() -> None:
 
         # Grafana
         grafana_ready = _wait_for(
-            ["kubectl", "get", "pods", "-n", "observability",
-             "-l", "app.kubernetes.io/name=grafana",
-             "-o", "jsonpath={.items[*].status.phase}"],
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "-n",
+                "observability",
+                "-l",
+                "app.kubernetes.io/name=grafana",
+                "-o",
+                "jsonpath={.items[*].status.phase}",
+            ],
             lambda out, err: "Running" in out,
             "Grafana pod",
-            timeout=180, interval=10, env=kenv,
+            timeout=180,
+            interval=10,
+            env=kenv,
         )
         if grafana_ready:
             _pass("Grafana pod is Running")
         else:
             _fail("Grafana pod not ready")
 
-        # ── Verify Grafana dashboard loaded ──
+        # Verify Grafana dashboard loaded
         _step("Verifying Grafana dashboard ConfigMap")
-        rc, out, err = _run([
-            "kubectl", "get", "configmap", "agentloom-grafana-dashboard",
-            "-n", "observability", "-o", "jsonpath={.data}",
-        ], env=kenv)
+        rc, out, err = _run(
+            [
+                "kubectl",
+                "get",
+                "configmap",
+                "agentloom-grafana-dashboard",
+                "-n",
+                "observability",
+                "-o",
+                "jsonpath={.data}",
+            ],
+            env=kenv,
+        )
         if rc == 0 and "agentloom.json" in out:
             _pass("Grafana dashboard ConfigMap contains agentloom.json")
         else:
             _fail("Grafana dashboard ConfigMap missing or empty")
 
-        # ── Verify OTel Collector service ──
+        # Verify OTel Collector service
         _step("Verifying OTel Collector service endpoint")
-        rc, out, err = _run([
-            "kubectl", "get", "svc", "-n", "observability",
-            "-o", "name",
-        ], env=kenv)
+        rc, out, err = _run(
+            [
+                "kubectl",
+                "get",
+                "svc",
+                "-n",
+                "observability",
+                "-o",
+                "name",
+            ],
+            env=kenv,
+        )
         if "otel-collector" in out:
             _pass("OTel Collector service exists in observability namespace")
         else:
             _fail("OTel Collector service not found")
 
-        # ── Verify all pods summary ──
+        # Verify all pods summary
         _step("Observability namespace pod summary")
-        rc, out, err = _run([
-            "kubectl", "get", "pods", "-n", "observability",
-            "--no-headers",
-        ], env=kenv)
+        rc, out, err = _run(
+            [
+                "kubectl",
+                "get",
+                "pods",
+                "-n",
+                "observability",
+                "--no-headers",
+            ],
+            env=kenv,
+        )
         if rc == 0:
-            lines = [l for l in out.strip().splitlines() if l.strip()]
-            running = [l for l in lines if "Running" in l or "Completed" in l]
+            lines = [ln for ln in out.strip().splitlines() if ln.strip()]
+            running = [ln for ln in lines if "Running" in ln or "Completed" in ln]
             _info(f"Total pods: {len(lines)}, Running/Completed: {len(running)}")
             for line in lines:
                 _info(f"  {line.strip()}")
@@ -799,23 +1103,39 @@ def phase_terraform() -> None:
             else:
                 _fail(f"Only {len(running)}/{len(lines)} pods healthy")
 
-        # ── Verify agentloom Helm release ──
+        # Verify agentloom Helm release
         _step("Verifying agentloom Helm release")
-        rc, out, err = _run([
-            "kubectl", "get", "jobs", "-n", "agentloom", "--no-headers",
-        ], env=kenv)
+        rc, out, err = _run(
+            [
+                "kubectl",
+                "get",
+                "jobs",
+                "-n",
+                "agentloom",
+                "--no-headers",
+            ],
+            env=kenv,
+        )
         if rc == 0 and "agentloom" in out:
-            _pass(f"AgentLoom job exists in agentloom namespace")
+            _pass("AgentLoom job exists in agentloom namespace")
             _info(out.strip())
         else:
             _fail("AgentLoom job not found in agentloom namespace")
 
-        # ── Verify OTel endpoint in agentloom pod ──
+        # Verify OTel endpoint in agentloom pod
         _step("Verifying OTel endpoint configuration in agentloom pod")
-        rc, out, err = _run([
-            "kubectl", "get", "job", "-n", "agentloom",
-            "-o", "jsonpath={.items[0].spec.template.spec.containers[0].env[?(@.name=='OTEL_EXPORTER_OTLP_ENDPOINT')].value}",
-        ], env=kenv)
+        rc, out, err = _run(
+            [
+                "kubectl",
+                "get",
+                "job",
+                "-n",
+                "agentloom",
+                "-o",
+                "jsonpath={.items[0].spec.template.spec.containers[0].env[?(@.name=='OTEL_EXPORTER_OTLP_ENDPOINT')].value}",
+            ],
+            env=kenv,
+        )
         if "otel-collector" in out and "observability" in out and "4317" in out:
             _pass(f"OTel endpoint points to in-cluster collector: {out}")
         elif "4317" in out:
@@ -823,7 +1143,7 @@ def phase_terraform() -> None:
         else:
             _fail(f"OTel endpoint unexpected: '{out}'")
 
-        # ── Verify NodePort mappings (Terraform outputs) ──
+        # Verify NodePort mappings (Terraform outputs)
         _step("Verifying Terraform outputs")
         for output_name in ["grafana_url", "prometheus_url", "jaeger_url"]:
             rc, out, err = _run(
@@ -838,12 +1158,19 @@ def phase_terraform() -> None:
     finally:
         # Cleanup
         _step("terraform destroy")
-        rc, out, err = _run([
-            "terraform", "destroy", "-auto-approve", "-input=false",
-            f"-var=cluster_name={cluster_name}",
-            "-var=enable_observability=true",
-            "-var=agentloom_image_tag=audit-int",
-        ], cwd=tf_dir, timeout=300)
+        rc, out, err = _run(
+            [
+                "terraform",
+                "destroy",
+                "-auto-approve",
+                "-input=false",
+                f"-var=cluster_name={cluster_name}",
+                "-var=enable_observability=true",
+                "-var=agentloom_image_tag=audit-int",
+            ],
+            cwd=tf_dir,
+            timeout=300,
+        )
         if rc == 0:
             _pass("terraform destroy succeeded")
         else:
@@ -862,10 +1189,7 @@ def phase_terraform() -> None:
     _save_phase("Terraform")
 
 
-# ────────────────────────────────────────────────────────────
 # Phase 5: Helm Direct Install
-# ────────────────────────────────────────────────────────────
-
 def phase_helm() -> None:
     _header("Phase 5: Helm — Direct Install into Kind")
     cluster_name = "audit-helm"
@@ -881,14 +1205,22 @@ def phase_helm() -> None:
     try:
         # Load image
         _step("Loading image into kind cluster")
-        _run(["kind", "load", "docker-image", "agentloom:audit-int", "--name", cluster_name], timeout=120)
+        _run(
+            ["kind", "load", "docker-image", "agentloom:audit-int", "--name", cluster_name],
+            timeout=120,
+        )
 
         # Helm lint
         _step("helm lint")
-        rc, out, err = _run([
-            "helm", "lint", str(DEPLOY / "helm" / "agentloom"),
-            "-f", str(DEPLOY / "helm" / "agentloom" / "ci" / "test-values.yaml"),
-        ])
+        rc, out, err = _run(
+            [
+                "helm",
+                "lint",
+                str(DEPLOY / "helm" / "agentloom"),
+                "-f",
+                str(DEPLOY / "helm" / "agentloom" / "ci" / "test-values.yaml"),
+            ]
+        )
         if rc == 0:
             _pass("helm lint passed")
         else:
@@ -896,17 +1228,30 @@ def phase_helm() -> None:
 
         # Helm install with validate-only workflow
         _step("helm install (validate-only workflow)")
-        rc, out, err = _run([
-            "helm", "install", "agentloom",
-            str(DEPLOY / "helm" / "agentloom"),
-            "-n", "agentloom", "--create-namespace",
-            "--set", "image.repository=agentloom",
-            "--set", "image.tag=audit-int",
-            "--set", "provider.existingSecret=",
-            "--set", "networkPolicy.enabled=false",
-            "--set", "observability.enabled=false",
-            "-f", str(DEPLOY / "helm" / "agentloom" / "ci" / "test-values.yaml"),
-        ], timeout=60)
+        rc, out, err = _run(
+            [
+                "helm",
+                "install",
+                "agentloom",
+                str(DEPLOY / "helm" / "agentloom"),
+                "-n",
+                "agentloom",
+                "--create-namespace",
+                "--set",
+                "image.repository=agentloom",
+                "--set",
+                "image.tag=audit-int",
+                "--set",
+                "provider.existingSecret=",
+                "--set",
+                "networkPolicy.enabled=false",
+                "--set",
+                "observability.enabled=false",
+                "-f",
+                str(DEPLOY / "helm" / "agentloom" / "ci" / "test-values.yaml"),
+            ],
+            timeout=60,
+        )
         if rc == 0:
             _pass("helm install succeeded")
         else:
@@ -917,7 +1262,7 @@ def phase_helm() -> None:
         _step("Verifying Helm-deployed resources")
         rc, out, err = _run(["kubectl", "get", "job", "-n", "agentloom", "--no-headers"])
         if rc == 0 and "agentloom" in out:
-            _pass(f"Job deployed via Helm")
+            _pass("Job deployed via Helm")
         else:
             _fail("No job found after helm install")
 
@@ -937,11 +1282,16 @@ def phase_helm() -> None:
 
         # Test validation: missing workflow should fail
         _step("Testing Helm validation (missing workflow → fail)")
-        rc, out, err = _run([
-            "helm", "template", "test",
-            str(DEPLOY / "helm" / "agentloom"),
-            "-n", "agentloom",
-        ])
+        rc, out, err = _run(
+            [
+                "helm",
+                "template",
+                "test",
+                str(DEPLOY / "helm" / "agentloom"),
+                "-n",
+                "agentloom",
+            ]
+        )
         if rc != 0:
             _pass("Helm correctly rejects missing workflow.definition")
         else:
@@ -963,38 +1313,39 @@ def phase_helm() -> None:
     _save_phase("Helm")
 
 
-# ────────────────────────────────────────────────────────────
 # Main
-# ────────────────────────────────────────────────────────────
-
 def main() -> int:
     global _verbose
 
     parser = argparse.ArgumentParser(description="AgentLoom Local Integration Audit")
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
-    parser.add_argument("--phase", type=int, choices=[1, 2, 3, 4, 5],
-                        help="Run only a specific phase (1=Docker, 2=Compose, 3=Kustomize, 4=Terraform, 5=Helm)")
+    parser.add_argument(
+        "--phase",
+        type=int,
+        choices=[1, 2, 3, 4, 5],
+        help="Run only a specific phase (1=Docker, 2=Compose, 3=Kustomize, 4=Terraform, 5=Helm)",
+    )
     args = parser.parse_args()
     _verbose = args.verbose
 
     print(_bold("\n  AgentLoom — Local Integration Audit"))
     print(f"  {'━' * 44}")
-    print(f"  Phases: Docker → Compose → Kustomize → Terraform → Helm")
+    print("  Phases: Docker → Compose → Kustomize → Terraform → Helm")
     print()
 
     phases = {
-        1: ("Docker",         phase_docker),
+        1: ("Docker", phase_docker),
         2: ("Docker Compose", phase_docker_compose),
-        3: ("Kustomize",      phase_kustomize),
-        4: ("Terraform",      phase_terraform),
-        5: ("Helm",           phase_helm),
+        3: ("Kustomize", phase_kustomize),
+        4: ("Terraform", phase_terraform),
+        5: ("Helm", phase_helm),
     }
 
     if args.phase:
         name, fn = phases[args.phase]
         fn()
     else:
-        for _, (name, fn) in sorted(phases.items()):
+        for _, (_name, fn) in sorted(phases.items()):
             fn()
 
     # Summary
@@ -1003,16 +1354,20 @@ def main() -> int:
     print(f"{'━' * 64}")
     for name, (p, f, s) in _phase_results.items():
         status = _green("PASS") if f == 0 else _red("FAIL")
-        print(f"  {status}  {name}: {_green(f'{p} passed')}  "
-              f"{_red(f'{f} failed') if f else '0 failed'}  "
-              f"{_yellow(f'{s} skipped') if s else ''}")
+        print(
+            f"  {status}  {name}: {_green(f'{p} passed')}  "
+            f"{_red(f'{f} failed') if f else '0 failed'}  "
+            f"{_yellow(f'{s} skipped') if s else ''}"
+        )
 
     total = _pass_count + _fail_count + _skip_count
     print(f"\n{'━' * 64}")
-    print(f"  {_bold('Total')}: {_green(f'{_pass_count} passed')}  "
-          f"{_red(f'{_fail_count} failed') if _fail_count else '0 failed'}  "
-          f"{_yellow(f'{_skip_count} skipped') if _skip_count else '0 skipped'}  "
-          f"({total} checks)")
+    print(
+        f"  {_bold('Total')}: {_green(f'{_pass_count} passed')}  "
+        f"{_red(f'{_fail_count} failed') if _fail_count else '0 failed'}  "
+        f"{_yellow(f'{_skip_count} skipped') if _skip_count else '0 skipped'}  "
+        f"({total} checks)"
+    )
     print(f"{'━' * 64}\n")
 
     return 1 if _fail_count > 0 else 0

--- a/scripts/observability-setup.sh
+++ b/scripts/observability-setup.sh
@@ -13,9 +13,7 @@ DEPLOY_DIR="$(cd "$(dirname "$0")/../deploy" && pwd)"
 # Global: filled by _ensure_compose
 DC=""
 
-# ---------------------------------------------------------------------------
 # Detect or install docker-compose
-# ---------------------------------------------------------------------------
 _detect_compose() {
     if docker compose version &> /dev/null 2>&1; then
         echo "docker compose"
@@ -53,9 +51,7 @@ _ensure_compose() {
     fi
 }
 
-# ---------------------------------------------------------------------------
 # down
-# ---------------------------------------------------------------------------
 if [[ "${1:-}" == "down" ]]; then
     _ensure_compose
     echo "Stopping observability stack..."
@@ -67,9 +63,7 @@ fi
 echo "=== AgentLoom Observability Setup ==="
 echo ""
 
-# ---------------------------------------------------------------------------
 # Check Docker engine (install if missing on macOS)
-# ---------------------------------------------------------------------------
 if ! command -v docker &> /dev/null; then
     echo "Docker not found."
     if [[ "$OSTYPE" == "darwin"* ]] && command -v brew &> /dev/null; then
@@ -97,16 +91,12 @@ fi
 
 echo "Docker: $(docker --version)"
 
-# ---------------------------------------------------------------------------
 # Ensure docker-compose (install if missing)
-# ---------------------------------------------------------------------------
 _ensure_compose
 echo "Compose: $DC"
 echo ""
 
-# ---------------------------------------------------------------------------
 # Install Python observability extras
-# ---------------------------------------------------------------------------
 echo "Installing observability Python packages..."
 if command -v uv &> /dev/null; then
     uv sync --group dev --all-extras
@@ -114,9 +104,7 @@ else
     pip install -e ".[observability]"
 fi
 
-# ---------------------------------------------------------------------------
 # Start the stack
-# ---------------------------------------------------------------------------
 echo ""
 echo "Starting observability stack..."
 $DC -f "$DEPLOY_DIR/docker-compose.yml" up -d

--- a/scripts/validate_approval_gate.py
+++ b/scripts/validate_approval_gate.py
@@ -37,10 +37,10 @@ class FakeProvider(BaseProvider):
 
     name = "fake"
 
-    async def complete(self, messages, model, **kwargs):  # noqa: ANN001,ANN003
+    async def complete(self, messages, model, **kwargs):
         return ProviderResponse(content="fake-output", model=model, provider="fake")
 
-    async def stream(self, *a, **kw):  # noqa: ANN002,ANN003
+    async def stream(self, *a, **kw):
         raise NotImplementedError
 
     def supports_model(self, model: str) -> bool:
@@ -95,7 +95,7 @@ async def main() -> None:
     with tempfile.TemporaryDirectory() as cp_dir:
         checkpointer = FileCheckpointer(checkpoint_dir=Path(cp_dir))
 
-        # ── Test 1: Run → should pause at approval gate ────────────
+        # Test 1: Run → should pause at approval gate
         print("\n[1/5] Running workflow (should pause at approval gate)...")
         engine = WorkflowEngine(
             workflow=_workflow(),
@@ -120,7 +120,7 @@ async def main() -> None:
         else:
             _fail(f"approve step should be PAUSED, got {result.step_results['approve'].status}")
 
-        # ── Test 2: Verify checkpoint ──────────────────────────────
+        # Test 2: Verify checkpoint
         print("\n[2/5] Verifying checkpoint...")
         loaded = await checkpointer.load("approval-validate")
 
@@ -134,7 +134,7 @@ async def main() -> None:
         else:
             _fail(f"Completed steps: {loaded.completed_steps}")
 
-        # ── Test 3: Resume with --approve ──────────────────────────
+        # Test 3: Resume with --approve
         print("\n[3/5] Resuming with decision=approved...")
         data = await checkpointer.load("approval-validate")
         resumed = await WorkflowEngine.from_checkpoint(
@@ -160,7 +160,7 @@ async def main() -> None:
         else:
             _fail("send step should be SUCCESS")
 
-        # ── Test 4: Run again → pause → resume with --reject ──────
+        # Test 4: Run again → pause → resume with --reject
         print("\n[4/5] Running again and resuming with decision=rejected...")
         engine2 = WorkflowEngine(
             workflow=_workflow(),
@@ -189,7 +189,7 @@ async def main() -> None:
         else:
             _fail(f"Decision in state: {result3.final_state.get('decision')}")
 
-        # ── Test 5: Final checkpoint status ────────────────────────
+        # Test 5: Final checkpoint status
         print("\n[5/5] Verifying final checkpoints...")
         final1 = await checkpointer.load("approval-validate")
         final2 = await checkpointer.load("approval-reject")

--- a/scripts/validate_pause_resume.py
+++ b/scripts/validate_pause_resume.py
@@ -35,18 +35,17 @@ from agentloom.providers.gateway import ProviderGateway
 from agentloom.steps.base import BaseStep, StepContext
 from agentloom.steps.registry import StepRegistry, create_default_registry
 
-# --- Helpers ----------------------------------------------------------------
 
-
+# Helpers
 class FakeProvider(BaseProvider):
     """Minimal provider that returns a fixed response."""
 
     name = "fake"
 
-    async def complete(self, messages, model, **kwargs):  # noqa: ANN001,ANN003
+    async def complete(self, messages, model, **kwargs):
         return ProviderResponse(content="fake-output", model=model, provider="fake")
 
-    async def stream(self, *a, **kw):  # noqa: ANN002,ANN003
+    async def stream(self, *a, **kw):
         raise NotImplementedError
 
     def supports_model(self, model: str) -> bool:
@@ -106,9 +105,7 @@ def _workflow() -> WorkflowDefinition:
     )
 
 
-# --- Validation -------------------------------------------------------------
-
-
+# Validation
 def _ok(msg: str) -> None:
     print(f"  ✓ {msg}")
 
@@ -122,7 +119,7 @@ async def main() -> None:
     with tempfile.TemporaryDirectory() as cp_dir:
         checkpointer = FileCheckpointer(checkpoint_dir=Path(cp_dir))
 
-        # ── Step 1: Run → should pause ──────────────────────────────
+        # Step 1: Run → should pause
         print("\n[1/4] Running workflow (should pause at step_b)...")
         engine = WorkflowEngine(
             workflow=_workflow(),
@@ -148,7 +145,7 @@ async def main() -> None:
         else:
             _fail(f"step_b should be PAUSED, got {result.step_results['step_b'].status}")
 
-        # ── Step 2: Verify checkpoint on disk ───────────────────────
+        # Step 2: Verify checkpoint on disk
         print("\n[2/4] Verifying checkpoint file...")
         cp_files = list(Path(cp_dir).glob("*.json"))
         if len(cp_files) == 1:
@@ -177,7 +174,7 @@ async def main() -> None:
         else:
             _fail("step_b should not be in completed_steps")
 
-        # ── Step 3: List runs ───────────────────────────────────────
+        # Step 3: List runs
         print("\n[3/4] Listing checkpoint runs...")
         runs = await checkpointer.list_runs()
         if len(runs) == 1 and runs[0].run_id == "validate-pause":
@@ -185,7 +182,7 @@ async def main() -> None:
         else:
             _fail(f"Expected 1 run, found {len(runs)}")
 
-        # ── Step 4: Resume → should complete ────────────────────────
+        # Step 4: Resume → should complete
         print("\n[4/4] Resuming workflow...")
         checkpoint_data = await checkpointer.load("validate-pause")
         resumed = await WorkflowEngine.from_checkpoint(

--- a/scripts/validate_webhook.py
+++ b/scripts/validate_webhook.py
@@ -76,7 +76,7 @@ def _wf(webhook_url: str | None = None) -> WorkflowDefinition:
 async def main() -> None:
     import anyio
 
-    # --- Phase 1: Webhook capture server ---
+    # Phase 1: Webhook capture server
     received_webhooks: list[dict] = []
 
     async def _capture_webhook(stream: anyio.abc.SocketStream) -> None:
@@ -101,7 +101,7 @@ async def main() -> None:
     with tempfile.TemporaryDirectory() as cp_dir:
         ckpt = FileCheckpointer(checkpoint_dir=Path(cp_dir))
 
-        # --- Phase 2: Run workflow (should pause and send webhook) ---
+        # Phase 2: Run workflow (should pause and send webhook)
         print("[1/5] Running workflow with webhook (should pause)...")
 
         async with anyio.create_task_group() as tg:
@@ -123,7 +123,7 @@ async def main() -> None:
             tg.start_soon(listener.serve, _capture_webhook)
             tg.start_soon(_run_and_cancel)
 
-        # --- Phase 3: Verify webhook received ---
+        # Phase 3: Verify webhook received
         print("[2/5] Verifying webhook payload...")
         assert len(received_webhooks) > 0, "No webhook received"
         wh = received_webhooks[0]
@@ -133,7 +133,7 @@ async def main() -> None:
         assert wh.get("status") == "awaiting_approval", f"Wrong status: {wh}"
         print(f"  OK: webhook payload valid — {wh}")
 
-        # --- Phase 4: Verify checkpoint ---
+        # Phase 4: Verify checkpoint
         print("[3/5] Verifying checkpoint...")
         loaded = await ckpt.load("wh-test")
         assert loaded.status == "paused"
@@ -141,7 +141,7 @@ async def main() -> None:
         assert "step_a" in loaded.completed_steps
         print("  OK: checkpoint valid")
 
-        # --- Phase 5: Resume with approval ---
+        # Phase 5: Resume with approval
         print("[4/5] Resuming with approval...")
         data = await ckpt.load("wh-test")
         resumed = await WorkflowEngine.from_checkpoint(
@@ -155,7 +155,7 @@ async def main() -> None:
         assert r2.final_state.get("decision") == "approved"
         print("  OK: resumed with approval")
 
-        # --- Phase 6: No webhook without config ---
+        # Phase 6: No webhook without config
         print("[5/5] Verifying no webhook when notify=None...")
         received_webhooks.clear()
         eng2 = WorkflowEngine(

--- a/src/agentloom/checkpointing/file.py
+++ b/src/agentloom/checkpointing/file.py
@@ -33,8 +33,6 @@ class FileCheckpointer(BaseCheckpointer):
     def __init__(self, checkpoint_dir: str | Path = ".agentloom/checkpoints") -> None:
         self._dir = Path(checkpoint_dir)
 
-    # -- path helpers ---------------------------------------------------------
-
     def _checkpoint_path(self, run_id: str) -> Path:
         """Resolve a safe checkpoint file path, rejecting traversal attempts."""
         if not run_id or not _RUN_ID_RE.fullmatch(run_id):
@@ -55,7 +53,7 @@ class FileCheckpointer(BaseCheckpointer):
         except (ValueError, KeyError) as exc:
             raise ValueError(f"Checkpoint '{source}' is unreadable or corrupted") from exc
 
-    # -- public API -----------------------------------------------------------
+    # public API
 
     async def save(self, data: CheckpointData) -> None:
         payload = data.model_dump_json(indent=2)
@@ -86,8 +84,6 @@ class FileCheckpointer(BaseCheckpointer):
             await anyio.to_thread.run_sync(partial(self._unlink, path))
         except FileNotFoundError as exc:
             raise KeyError(f"No checkpoint found for run '{run_id}'") from exc
-
-    # -- sync helpers (run in worker thread) ----------------------------------
 
     def _write(self, run_id: str, payload: str) -> None:
         self._dir.mkdir(parents=True, exist_ok=True)

--- a/src/agentloom/cli/resume.py
+++ b/src/agentloom/cli/resume.py
@@ -65,7 +65,6 @@ async def _resume_async(
     from agentloom.tools.registry import ToolRegistry
     from agentloom.tools.sandbox import ToolSandbox
 
-    # Load checkpoint
     checkpointer = FileCheckpointer(checkpoint_dir=checkpoint_dir)
     try:
         checkpoint_data = await checkpointer.load(run_id)
@@ -73,7 +72,6 @@ async def _resume_async(
         typer.echo(f"No checkpoint found for run '{run_id}'.", err=True)
         raise typer.Exit(1)
 
-    # Build approval decisions map for the paused step
     approval_decisions: dict[str, str] = {}
     if decision:
         if checkpoint_data.status != "paused" or not checkpoint_data.paused_step_id:
@@ -95,14 +93,12 @@ async def _resume_async(
             f"(run {run_id}, status={checkpoint_data.status})"
         )
 
-    # Reconstruct engine
     engine = await WorkflowEngine.from_checkpoint(
         checkpoint_data=checkpoint_data,
         checkpointer=checkpointer,
         approval_decisions=approval_decisions or None,
     )
 
-    # Apply overrides
     if provider_override:
         engine.workflow.config.provider = provider_override
     if model_override:
@@ -110,12 +106,10 @@ async def _resume_async(
     if stream:
         engine.workflow.config.stream = True
 
-    # Setup providers
     gateway = ProviderGateway()
     _setup_providers(gateway, engine.workflow.config.provider)
     engine.provider_gateway = gateway
 
-    # Setup tools
     sandbox_cfg = engine.workflow.config.sandbox
     sandbox = ToolSandbox(
         enabled=sandbox_cfg.enabled,
@@ -131,7 +125,6 @@ async def _resume_async(
     register_builtins(tool_registry, sandbox=sandbox)
     engine.tool_registry = tool_registry
 
-    # Observability
     observer = _setup_observer(lite)
     engine.observer = observer
     if observer and gateway:  # pragma: no cover — requires OTel extra
@@ -139,7 +132,6 @@ async def _resume_async(
         if set_obs:
             set_obs(observer)
 
-    # Stream callback
     if stream and not output_json:
 
         def _on_chunk(step_id: str, text: str) -> None:
@@ -147,7 +139,6 @@ async def _resume_async(
 
         engine._stream_callback = _on_chunk
 
-    # Run
     result = await engine.run()
 
     if stream and not output_json:

--- a/src/agentloom/cli/run.py
+++ b/src/agentloom/cli/run.py
@@ -70,14 +70,12 @@ async def _run_async(
     from agentloom.tools.registry import ToolRegistry
     from agentloom.tools.sandbox import ToolSandbox
 
-    # Parse workflow
     try:
         workflow = WorkflowParser.from_yaml(workflow_path)
     except Exception as e:
         typer.echo(f"Error loading workflow: {e}", err=True)
         raise typer.Exit(1)
 
-    # Apply overrides
     if provider_override:
         workflow.config.provider = provider_override
     if model_override:
@@ -87,7 +85,6 @@ async def _run_async(
     if stream:
         workflow.config.stream = True
 
-    # Parse state overrides
     initial_state = dict(workflow.state)
     for item in state_args:
         if "=" not in item:
@@ -98,11 +95,9 @@ async def _run_async(
 
     state_manager = StateManager(initial_state=initial_state)
 
-    # Setup provider gateway
     gateway = ProviderGateway()
     _setup_providers(gateway, workflow.config.provider)
 
-    # Setup tools with sandbox from workflow config
     sandbox_cfg = workflow.config.sandbox
     sandbox = ToolSandbox(
         enabled=sandbox_cfg.enabled,
@@ -117,10 +112,8 @@ async def _run_async(
     tool_registry = ToolRegistry()
     register_builtins(tool_registry, sandbox=sandbox)
 
-    # Setup observability (unless --lite)
     observer = _setup_observer(lite)
 
-    # Setup stream callback
     stream_callback = None
     if stream and not output_json:
 
@@ -129,14 +122,12 @@ async def _run_async(
 
         stream_callback = _on_chunk
 
-    # Setup checkpointer
     checkpointer = None
     if checkpoint:
         from agentloom.checkpointing.file import FileCheckpointer
 
         checkpointer = FileCheckpointer(checkpoint_dir=checkpoint_dir)
 
-    # Run engine
     engine = WorkflowEngine(
         workflow=workflow,
         state_manager=state_manager,
@@ -155,7 +146,6 @@ async def _run_async(
     if stream and not output_json:
         typer.echo()  # Newline after streamed output
 
-    # Output results
     if output_json:
         typer.echo(result.model_dump_json(indent=2))
     else:
@@ -279,7 +269,6 @@ def _print_result(result: object) -> None:
             line += f" [{sr.attachment_count} attachment{'s' if sr.attachment_count > 1 else ''}]"
         typer.echo(line)
 
-    # Show final output
     final_state = r.final_state
     typer.echo(f"\nFinal State Keys: {list(final_state.keys())}")
     typer.echo(f"{'=' * 60}")

--- a/src/agentloom/cli/visualize.py
+++ b/src/agentloom/cli/visualize.py
@@ -84,7 +84,6 @@ def _print_mermaid(workflow: object, dag: object) -> None:
     typer.echo("```mermaid")
     typer.echo("graph TD")
 
-    # Define nodes
     for step in w.steps:
         stype = step_types.get(step.id, StepType.LLM_CALL)
         if stype == StepType.ROUTER:
@@ -96,12 +95,10 @@ def _print_mermaid(workflow: object, dag: object) -> None:
         else:
             typer.echo(f"    {step.id}[{step.id}]")
 
-    # Define edges
     for step in w.steps:
         for dep in step.depends_on:
             dep_step = w.get_step(dep)
             if dep_step and dep_step.type == StepType.ROUTER:
-                # Show router conditions as edge labels
                 for cond in dep_step.conditions:
                     if cond.target == step.id:
                         label = cond.expression[:20]

--- a/src/agentloom/config.py
+++ b/src/agentloom/config.py
@@ -20,7 +20,6 @@ class ProviderConfig(BaseModel):
     timeout: float = 30.0
 
 
-# Provider defaults used when auto-discovering from API-key env vars.
 _PROVIDER_DEFAULTS: dict[str, dict[str, object]] = {
     "openai": {
         "env_key": "OPENAI_API_KEY",
@@ -56,7 +55,6 @@ class AgentLoomConfig(BaseModel):
     providers: list[ProviderConfig] = Field(default_factory=list)
 
 
-# Mapping from AGENTLOOM_* env var suffix → (field_name, type_converter).
 _ENV_MAP: dict[str, tuple[str, type]] = {
     "LOG_LEVEL": ("log_level", str),
     "LOG_FORMAT": ("log_format", str),

--- a/src/agentloom/core/dag.py
+++ b/src/agentloom/core/dag.py
@@ -46,7 +46,6 @@ class DAG:
         """Validate the DAG. Returns a list of error messages (empty if valid)."""
         errors: list[str] = []
 
-        # Check for cycles via DFS
         WHITE, GRAY, BLACK = 0, 1, 2
         color: dict[str, int] = {n: WHITE for n in self._nodes}
         cycle_path: list[str] = []
@@ -70,7 +69,6 @@ class DAG:
             if color[node] == WHITE:
                 dfs(node)
 
-        # Check for edges to non-existent nodes
         for node, succs in self._edges.items():
             for succ in succs:
                 if succ not in self._nodes:
@@ -121,7 +119,6 @@ class DAG:
         remaining = set(self._nodes)
 
         while remaining:
-            # Current layer: nodes with no unresolved dependencies
             layer = sorted(n for n in remaining if in_degree[n] == 0)
             if not layer:
                 raise ValidationError("Workflow DAG contains a cycle")

--- a/src/agentloom/core/engine.py
+++ b/src/agentloom/core/engine.py
@@ -78,7 +78,6 @@ class WorkflowEngine:
         self._stream_callback = on_stream_chunk
         self._budget_spent: float = 0.0
 
-        # Checkpointing
         self._checkpointer = checkpointer
         self.run_id = run_id or (uuid.uuid4().hex[:12] if checkpointer else "")
         self._completed_steps: set[str] = set()
@@ -197,7 +196,6 @@ class WorkflowEngine:
         if self.observer:
             self.observer.on_workflow_start(workflow_name)
 
-        # Build and validate DAG
         dag = WorkflowParser.build_dag(self.workflow)
         layers = dag.execution_layers()
 
@@ -265,7 +263,6 @@ class WorkflowEngine:
                 if not active_steps:
                     continue
 
-                # Execute steps in this layer concurrently
                 max_concurrent = self.workflow.config.max_concurrent_steps
                 limiter = anyio.CapacityLimiter(max_concurrent)
 
@@ -273,13 +270,11 @@ class WorkflowEngine:
                     for step_id in active_steps:
                         tg.start_soon(self._execute_step_with_limit, step_id, limiter)
 
-                # Track completed steps for checkpoint/resume
                 for step_id in active_steps:
                     step_result = await self.state.get_step_result(step_id)
                     if step_result and step_result.status == StepStatus.SUCCESS:
                         self._completed_steps.add(step_id)
 
-                # After layer execution, check for router results
                 activated_targets_for_next = set()
                 for step_id in active_steps:
                     step_def = self.workflow.get_step(step_id)
@@ -305,7 +300,6 @@ class WorkflowEngine:
                     if activated_targets is not None:
                         activated_targets = None
 
-            # Gather results
             duration = (time.monotonic() - start) * 1000
             step_results = await self.state.all_step_results()
             final_state = await self.state.get_state_snapshot()
@@ -313,7 +307,6 @@ class WorkflowEngine:
             total_tokens = sum(r.token_usage.total_tokens for r in step_results.values())
             total_cost = sum(r.cost_usd for r in step_results.values())
 
-            # Determine workflow status
             failed_steps = [r for r in step_results.values() if r.status == StepStatus.FAILED]
             status = WorkflowStatus.FAILED if failed_steps else WorkflowStatus.SUCCESS
 
@@ -445,11 +438,9 @@ class WorkflowEngine:
         if self.observer:
             self.observer.on_step_start(step_id, step_def.type.value, stream=should_stream)
 
-        # Get the executor
         executor_cls = self.step_registry.get(step_def.type)
         executor: BaseStep = executor_cls()
 
-        # Build context
         context = StepContext(
             step_definition=step_def,
             state_manager=self.state,
@@ -465,7 +456,6 @@ class WorkflowEngine:
             on_stream_chunk=self._stream_callback,
         )
 
-        # Execute with retry
         max_retries = step_def.retry.max_retries
         last_result: StepResult | None = None
 
@@ -542,7 +532,6 @@ class WorkflowEngine:
                     )
                     return
 
-                # Failed but might retry
                 if attempt < max_retries:
                     # FIXME: jitter not applied here, only in resilience/retry.py
                     backoff = min(
@@ -607,7 +596,6 @@ class WorkflowEngine:
                     continue
                 break
 
-        # All retries exhausted
         if last_result:
             await self.state.set_step_result(step_id, last_result)
 

--- a/src/agentloom/core/graph.py
+++ b/src/agentloom/core/graph.py
@@ -85,7 +85,6 @@ class WorkflowGraph:
 
         dag = WorkflowParser.build_dag(workflow)
 
-        # Build node map: step_id -> GraphNode
         nodes: list[GraphNode] = [
             GraphNode(
                 id=step.id,
@@ -96,7 +95,6 @@ class WorkflowGraph:
             for step in workflow.steps
         ]
 
-        # Build edges with labels derived from router conditions
         edges: list[GraphEdge] = []
         router_targets: dict[str, dict[str, str]] = {}  # step_id -> {target -> label}
 
@@ -220,10 +218,8 @@ class WorkflowGraph:
 
         The result is deterministically sorted.
         """
-        # Start with all single-node paths.
         paths: list[list[str]] = [[node_id] for node_id in sorted(self._dag.nodes)]
 
-        # Iteratively extend each path.
         changed = True
         while changed:
             changed = False
@@ -246,7 +242,6 @@ class WorkflowGraph:
                     f"Graph is too complex; pass a higher max_paths to override."
                 )
 
-        # De-duplicate.
         seen: set[tuple[str, ...]] = set()
         unique: list[list[str]] = []
         for path in paths:
@@ -255,7 +250,6 @@ class WorkflowGraph:
                 seen.add(key)
                 unique.append(path)
 
-        # Filter: remove any path that is a contiguous sub-sequence of another.
         def is_subpath(candidate: list[str], other: list[str]) -> bool:
             if len(candidate) >= len(other):
                 return False

--- a/src/agentloom/core/parser.py
+++ b/src/agentloom/core/parser.py
@@ -61,7 +61,6 @@ class WorkflowParser:
 
         WorkflowParser._validate_references(workflow)
 
-        # Validate DAG (cycle detection) during parsing
         steps = [(s.id, s.depends_on) for s in workflow.steps]
         dag = DAG.from_steps(steps)
         errors = dag.validate()

--- a/src/agentloom/core/state.py
+++ b/src/agentloom/core/state.py
@@ -113,8 +113,6 @@ class StateManager:
         """Direct access to state dict (use in sync contexts only)."""
         return self._state
 
-    # -- Checkpointing --
-
     async def save_checkpoint(self, path: str | Path) -> None:
         """Save current state to a JSON file."""
         async with self._lock:
@@ -142,8 +140,6 @@ class StateManager:
             manager._step_results[step_id] = StepResult.model_validate(result_data)
             manager._step_status[step_id] = manager._step_results[step_id].status
         return manager
-
-    # -- Internal helpers --
 
     @staticmethod
     def _resolve_key(data: dict[str, Any], key: str, default: Any = None) -> Any:

--- a/src/agentloom/observability/metrics.py
+++ b/src/agentloom/observability/metrics.py
@@ -77,8 +77,6 @@ class MetricsManager:
         elif _HAS_PROM:  # pragma: no cover — prom fallback, only active when OTel unavailable
             self._setup_prom()
 
-    # Setup
-
     def _setup_otel(self, endpoint: str) -> None:
         exporter = otel_metric_exporter.OTLPMetricExporter(endpoint=endpoint, insecure=True)
         reader = otel_metrics.export.PeriodicExportingMetricReader(
@@ -157,7 +155,7 @@ class MetricsManager:
         # Circuit breaker gauge (callback-based, reads from _circuit_states)
         states = self._circuit_states
 
-        def _cb_circuit(options: Any) -> Any:  # noqa: ANN401
+        def _cb_circuit(options: Any) -> Any:
             Observation = otel_api_metrics.Observation
             for prov, val in list(states.items()):  # pragma: no cover — fires on OTel export
                 yield Observation(val, {"provider": prov})
@@ -171,7 +169,7 @@ class MetricsManager:
         # Budget remaining gauge (callback-based, reads from _budget_remaining)
         budget = self._budget_remaining
 
-        def _cb_budget(options: Any) -> Any:  # noqa: ANN401  # pragma: no cover
+        def _cb_budget(options: Any) -> Any:  # pragma: no cover
             Observation = otel_api_metrics.Observation
             for wf, val in list(budget.items()):
                 yield Observation(val, {"workflow": wf})
@@ -269,8 +267,6 @@ class MetricsManager:
         )
         self._backend = "prom"
         logger.debug("Metrics: prometheus_client (pull)")
-
-    # Recording
 
     def record_workflow_run(
         self, workflow: str, status: str, duration_s: float = 0.0, cost_usd: float = 0.0

--- a/src/agentloom/observability/observer.py
+++ b/src/agentloom/observability/observer.py
@@ -50,13 +50,11 @@ class WorkflowObserver:
         total_tokens: int,
         total_cost: float,
     ) -> None:
-        # Metrics
         if self._metrics:
             self._metrics.record_workflow_run(
                 workflow_name, status, duration_ms / 1000.0, total_cost
             )
 
-        # Span
         span = self._workflow_span
         if span:
             span.set_attribute("workflow.status", status)
@@ -96,7 +94,6 @@ class WorkflowObserver:
         time_to_first_token_ms: float | None = None,
         stream: bool = False,
     ) -> None:
-        # Metrics
         if self._metrics:
             self._metrics.record_step_execution(
                 step_type, status, duration_ms / 1000.0, stream=stream
@@ -104,7 +101,6 @@ class WorkflowObserver:
             if attachment_count > 0:
                 self._metrics.record_attachments(step_type, attachment_count)
 
-        # Span
         span = self._step_spans.pop(step_id, None)
         if span:
             span.set_attribute("step.status", status)

--- a/src/agentloom/observability/tracing.py
+++ b/src/agentloom/observability/tracing.py
@@ -16,7 +16,6 @@ otel_exporter = try_import(
     "opentelemetry.exporter.otlp.proto.grpc.trace_exporter", extra="observability"
 )
 
-# good enough — if someone installs only otel-api without sdk, they get noops
 _HAS_OTEL = is_available(otel_api) and is_available(otel_sdk_trace)
 
 

--- a/src/agentloom/providers/anthropic.py
+++ b/src/agentloom/providers/anthropic.py
@@ -146,7 +146,6 @@ class AnthropicProvider(BaseProvider):
 
         data = response.json()
 
-        # Extract content from content blocks
         content_blocks = data.get("content", [])
         content = ""
         for block in content_blocks:

--- a/src/agentloom/providers/google.py
+++ b/src/agentloom/providers/google.py
@@ -121,14 +121,12 @@ class GoogleProvider(BaseProvider):
 
         data = response.json()
 
-        # Extract content
         candidates = data.get("candidates", [])
         content = ""
         if candidates:
             parts = candidates[0].get("content", {}).get("parts", [])
             content = "".join(p.get("text", "") for p in parts)
 
-        # Extract usage
         usage_data = data.get("usageMetadata", {})
         usage = TokenUsage(
             prompt_tokens=usage_data.get("promptTokenCount", 0),

--- a/src/agentloom/providers/multimodal.py
+++ b/src/agentloom/providers/multimodal.py
@@ -22,10 +22,6 @@ logger = logging.getLogger("agentloom.multimodal")
 # Maximum attachment size after download/read (20 MB).
 MAX_ATTACHMENT_BYTES = 20 * 1024 * 1024
 
-# ---------------------------------------------------------------------------
-# Content block types — the internal format that flows through the gateway
-# ---------------------------------------------------------------------------
-
 
 class TextBlock(BaseModel):
     """A text content block."""
@@ -68,10 +64,6 @@ class AudioBlock(BaseModel):
 
 ContentBlock = TextBlock | ImageBlock | ImageURLBlock | DocumentBlock | AudioBlock
 
-
-# ---------------------------------------------------------------------------
-# Media type detection
-# ---------------------------------------------------------------------------
 
 _EXTENSION_MEDIA_TYPES: dict[str, str] = {
     # Images
@@ -116,11 +108,6 @@ def detect_media_type(source: str, attachment_type: str = "image") -> str:
     return _MEDIA_TYPE_DEFAULTS.get(attachment_type, "application/octet-stream")
 
 
-# ---------------------------------------------------------------------------
-# Source classification
-# ---------------------------------------------------------------------------
-
-
 def _is_url(source: str) -> bool:
     """Return True if *source* looks like an HTTP(S) URL (case-insensitive)."""
     return source.lower().startswith(("http://", "https://"))
@@ -145,10 +132,6 @@ def _is_base64(source: str) -> bool:
             return False
     return False
 
-
-# ---------------------------------------------------------------------------
-# Security: SSRF protection + sandbox validation
-# ---------------------------------------------------------------------------
 
 _BLOCKED_NETWORKS = [
     ipaddress.ip_network("0.0.0.0/8"),
@@ -275,11 +258,6 @@ def _check_size(data: bytes, source: str) -> None:
         raise ValueError(msg)
 
 
-# ---------------------------------------------------------------------------
-# Fetching / reading
-# ---------------------------------------------------------------------------
-
-
 async def _validate_redirect_target(response: httpx.Response) -> None:
     """Event hook: validate each redirect target against SSRF rules.
 
@@ -324,11 +302,6 @@ async def _fetch_url(url: str) -> tuple[bytes, str | None]:
         return data, content_type
 
 
-# ---------------------------------------------------------------------------
-# Block builders per attachment type
-# ---------------------------------------------------------------------------
-
-
 def _make_block(
     attachment_type: str,
     data: str,
@@ -357,11 +330,6 @@ def _make_url_block(
     raise ValueError(msg)
 
 
-# ---------------------------------------------------------------------------
-# Single-attachment resolver
-# ---------------------------------------------------------------------------
-
-
 async def _resolve_single(
     attachment: Attachment,
     sandbox: SandboxConfig,
@@ -378,7 +346,6 @@ async def _resolve_single(
             _validate_provider_url(source, sandbox)
             return _make_url_block(attachment.type, source, media_type)
 
-        # fetch: local (default) — download and base64-encode
         await _validate_url_sandbox(source, sandbox)
         raw_bytes, content_type = await _fetch_url(source)
         if not attachment.media_type and content_type:
@@ -389,7 +356,6 @@ async def _resolve_single(
     if _is_base64(source):
         return _make_block(attachment.type, source, media_type)
 
-    # Treat as local file path — resolve symlinks first, then validate and read
     resolved = str(Path(source).resolve())
     _validate_file_sandbox(source, sandbox)
     path = anyio.Path(resolved)
@@ -426,11 +392,6 @@ async def resolve_attachments(
         block = await _resolve_single(att, cfg)
         blocks.append(block)
     return blocks
-
-
-# ---------------------------------------------------------------------------
-# Message building
-# ---------------------------------------------------------------------------
 
 
 def build_multimodal_content(

--- a/src/agentloom/providers/pricing.py
+++ b/src/agentloom/providers/pricing.py
@@ -48,7 +48,6 @@ def load_pricing(custom_path: str | None = None) -> dict[str, ModelPricing]:
     return _load_pricing_yaml(_BUNDLED_PRICING_PATH)
 
 
-# Module-level table — populated on first import.
 DEFAULT_PRICING: dict[str, ModelPricing] = load_pricing()
 
 

--- a/src/agentloom/resilience/rate_limiter.py
+++ b/src/agentloom/resilience/rate_limiter.py
@@ -21,11 +21,9 @@ class RateLimiter:
         self.max_rpm = max_requests_per_minute
         self.max_tpm = max_tokens_per_minute
 
-        # Request bucket
         self._request_tokens = float(max_requests_per_minute)
         self._request_last_refill = time.monotonic()
 
-        # Token bucket
         self._token_tokens = float(max_tokens_per_minute)
         self._token_last_refill = time.monotonic()
 
@@ -55,15 +53,12 @@ class RateLimiter:
             async with self._lock:
                 self._refill()
 
-                # Check request bucket
                 if self._request_tokens < 1.0:
                     wait_time = (1.0 - self._request_tokens) / (self.max_rpm / 60.0)
                 else:
-                    # Check token bucket (if applicable)
                     if token_count > 0 and self._token_tokens < token_count:
                         wait_time = (token_count - self._token_tokens) / (self.max_tpm / 60.0)
                     else:
-                        # Consume tokens
                         self._request_tokens -= 1.0
                         if token_count > 0:
                             self._token_tokens -= token_count
@@ -76,7 +71,6 @@ class RateLimiter:
         """Refill token buckets based on elapsed time."""
         now = time.monotonic()
 
-        # Refill request bucket
         elapsed = now - self._request_last_refill
         self._request_tokens = min(
             float(self.max_rpm),
@@ -84,7 +78,6 @@ class RateLimiter:
         )
         self._request_last_refill = now
 
-        # Refill token bucket
         elapsed_t = now - self._token_last_refill
         self._token_tokens = min(
             float(self.max_tpm),

--- a/src/agentloom/resilience/retry.py
+++ b/src/agentloom/resilience/retry.py
@@ -65,7 +65,7 @@ async def retry_with_policy(
             )
 
             if policy.jitter:
-                backoff *= 1.0 + random.uniform(-0.25, 0.25)
+                backoff *= 1.0 + random.uniform(-0.25, 0.25)  # noqa: S311
 
             logger.warning(
                 "%s failed (attempt %d/%d), retrying in %.1fs: %s",

--- a/src/agentloom/resilience/retry.py
+++ b/src/agentloom/resilience/retry.py
@@ -59,15 +59,13 @@ async def retry_with_policy(
             if attempt >= policy.max_retries:
                 break
 
-            # Calculate backoff
             backoff = min(
                 policy.backoff_base**attempt,
                 policy.backoff_max,
             )
 
-            # Add jitter (up to 25% variation)
             if policy.jitter:
-                backoff *= 1.0 + random.uniform(-0.25, 0.25)  # noqa: S311
+                backoff *= 1.0 + random.uniform(-0.25, 0.25)
 
             logger.warning(
                 "%s failed (attempt %d/%d), retrying in %.1fs: %s",

--- a/src/agentloom/steps/approval_gate.py
+++ b/src/agentloom/steps/approval_gate.py
@@ -27,21 +27,17 @@ class ApprovalGateStep(BaseStep):
         step = context.step_definition
         start = time.monotonic()
 
-        # Check whether a decision was injected into state on resume
         decision = await context.state_manager.get(f"_approval.{step.id}")
 
         if decision is None:
-            # Send webhook notification before pausing
             if step.notify:
                 await self._send_notification(context)
 
-            # Record pending approval metric
             if context.observer:
                 hook = getattr(context.observer, "on_approval_gate", None)
                 if hook:
                     hook(step.id, context.workflow_name, "pending")
 
-            # First execution — print instructions and pause
             print(
                 f"\n[APPROVAL REQUIRED] Step '{step.id}' is waiting for approval.\n"
                 f"  Resume with: agentloom resume <run_id> --approve\n"
@@ -50,14 +46,12 @@ class ApprovalGateStep(BaseStep):
             )
             raise PauseRequestedError(step.id, f"Approval required at step '{step.id}'")
 
-        # Validate the decision value
         if decision not in ("approved", "rejected"):
             raise StepError(
                 step.id,
                 f"Invalid approval decision '{decision}'. Expected 'approved' or 'rejected'.",
             )
 
-        # Record decision metric
         if context.observer:
             hook = getattr(context.observer, "on_approval_gate", None)
             if hook:
@@ -65,7 +59,6 @@ class ApprovalGateStep(BaseStep):
 
         duration = (time.monotonic() - start) * 1000
 
-        # Store the decision in the output state variable
         if step.output:
             await context.state_manager.set(step.output, decision)
 

--- a/src/agentloom/steps/llm_call.py
+++ b/src/agentloom/steps/llm_call.py
@@ -33,11 +33,9 @@ class LLMCallStep(BaseStep):
         if not step.prompt:
             raise StepError(step.id, "LLM call step requires a 'prompt' field")
 
-        # Resolve model: step-level override > workflow config
         model = step.model or context.workflow_model
         state_snapshot = await context.state_manager.get_state_snapshot()
 
-        # Build a flat namespace for template rendering
         template_vars = build_template_vars(state_snapshot)
 
         try:
@@ -48,7 +46,6 @@ class LLMCallStep(BaseStep):
         except (KeyError, ValueError) as e:
             raise StepError(step.id, f"Prompt template error: {e}") from e
 
-        # Resolve multimodal attachments
         content_blocks: list[ContentBlock] = []
         if step.attachments:
             try:
@@ -70,14 +67,12 @@ class LLMCallStep(BaseStep):
             except Exception as e:
                 raise StepError(step.id, f"Attachment resolution error: {e}") from e
 
-        # Build messages
         messages: list[dict[str, Any]] = []
         if rendered_system:
             messages.append({"role": "system", "content": rendered_system})
         user_content = build_multimodal_content(rendered_prompt, content_blocks)
         messages.append({"role": "user", "content": user_content})
 
-        # Call provider (streaming or batch)
         if context.stream:
             return await self._execute_stream(
                 context, messages, model, step, start, len(content_blocks)
@@ -101,7 +96,6 @@ class LLMCallStep(BaseStep):
 
         duration = (time.monotonic() - start) * 1000
 
-        # Store output in state if output mapping is defined
         if step.output:
             await context.state_manager.set(step.output, response.content)
 

--- a/src/agentloom/steps/router.py
+++ b/src/agentloom/steps/router.py
@@ -46,7 +46,6 @@ _ALLOWED_NODES = (
     ast.IfExp,
 )
 
-# Functions allowed in expressions
 _SAFE_BUILTINS = {
     "len": len,
     "str": str,
@@ -60,7 +59,6 @@ _SAFE_BUILTINS = {
     "type": type,
 }
 
-# Allowed function names for AST validation
 _ALLOWED_FUNCTIONS = set(_SAFE_BUILTINS.keys())
 
 
@@ -81,7 +79,6 @@ def _validate_expression(expr_str: str) -> ast.Expression:
                 f"Disallowed expression construct: {type(node).__name__}. "
                 f"Only comparisons, boolean ops, and safe builtins are allowed."
             )
-        # Check function calls are to allowed names only
         if isinstance(node, ast.Call):
             if isinstance(node.func, ast.Name):
                 if node.func.id not in _ALLOWED_FUNCTIONS:
@@ -110,7 +107,7 @@ def evaluate_expression(expr_str: str, namespace: dict[str, Any]) -> Any:
     safe_globals: dict[str, Any] = {"__builtins__": {}}
     safe_globals.update(_SAFE_BUILTINS)
     safe_globals.update(namespace)
-    return eval(code, safe_globals)  # noqa: S307
+    return eval(code, safe_globals)
 
 
 class RouterStep(BaseStep):
@@ -125,7 +122,6 @@ class RouterStep(BaseStep):
 
         state_snapshot = await context.state_manager.get_state_snapshot()
 
-        # Build namespace with state access
         namespace: dict[str, Any] = {}
         namespace.update(state_snapshot)
 
@@ -135,7 +131,6 @@ class RouterStep(BaseStep):
 
         namespace["state"] = _StateProxy()
 
-        # Also expose step results
         steps_data = state_snapshot.get("steps", {})
 
         class _StepsProxy:
@@ -152,7 +147,6 @@ class RouterStep(BaseStep):
 
         namespace["steps"] = _StepsProxy()
 
-        # Evaluate conditions in order
         # NOTE: first matching condition wins. no priority system yet
         target: str | None = None
         for condition in step.conditions:
@@ -167,7 +161,6 @@ class RouterStep(BaseStep):
                     f"Error evaluating condition '{condition.expression}': {e}",
                 ) from e
 
-        # Fallback to default
         if target is None:
             target = step.default
 
@@ -176,7 +169,6 @@ class RouterStep(BaseStep):
 
         duration = (time.monotonic() - start) * 1000
 
-        # Store the routing decision in state
         if step.output:
             await context.state_manager.set(step.output, target)
 

--- a/src/agentloom/steps/subworkflow.py
+++ b/src/agentloom/steps/subworkflow.py
@@ -16,12 +16,10 @@ class SubworkflowStep(BaseStep):
         step = context.step_definition
         start = time.monotonic()
 
-        # Import here to avoid circular imports
         from agentloom.core.engine import WorkflowEngine
         from agentloom.core.parser import WorkflowParser
         from agentloom.core.state import StateManager
 
-        # Load the sub-workflow definition
         if step.workflow_path:
             try:
                 sub_workflow = WorkflowParser.from_yaml(step.workflow_path)
@@ -38,11 +36,9 @@ class SubworkflowStep(BaseStep):
                 "Subworkflow step requires 'workflow_path' or 'workflow_inline'",
             )
 
-        # Create child state with parent state snapshot
         parent_state = await context.state_manager.get_state_snapshot()
         child_state = StateManager(initial_state=parent_state)
 
-        # Create and run nested engine
         engine = WorkflowEngine(
             workflow=sub_workflow,
             state_manager=child_state,
@@ -63,7 +59,6 @@ class SubworkflowStep(BaseStep):
 
         duration = (time.monotonic() - start) * 1000
 
-        # Merge child state back into parent
         # TODO: selective merge — right now dumps entire child state back
         child_final = result.final_state
         if step.output:
@@ -73,7 +68,6 @@ class SubworkflowStep(BaseStep):
             StepStatus.SUCCESS if result.status == WorkflowStatus.SUCCESS else StepStatus.FAILED
         )
 
-        # Aggregate token usage from all child steps
         from agentloom.core.results import TokenUsage
 
         total_prompt = sum(r.token_usage.prompt_tokens for r in result.step_results.values())

--- a/src/agentloom/steps/tool_step.py
+++ b/src/agentloom/steps/tool_step.py
@@ -24,17 +24,14 @@ class ToolStep(BaseStep):
         if not step.tool_name:
             raise StepError(step.id, "Tool step requires a 'tool_name' field")
 
-        # Get the tool
         try:
             tool = context.tool_registry.get(step.tool_name)
         except KeyError as e:
             raise StepError(step.id, str(e)) from e
 
-        # Resolve tool arguments from state
         state_snapshot = await context.state_manager.get_state_snapshot()
         resolved_args = self._resolve_args(step.tool_args, state_snapshot)
 
-        # Execute the tool
         try:
             result = await tool.execute(**resolved_args)
         except Exception as e:
@@ -48,7 +45,6 @@ class ToolStep(BaseStep):
 
         duration = (time.monotonic() - start) * 1000
 
-        # Store output
         if step.output:
             await context.state_manager.set(step.output, result)
 

--- a/src/agentloom/tools/decorator.py
+++ b/src/agentloom/tools/decorator.py
@@ -44,7 +44,6 @@ def tool(
     return decorator
 
 
-# Mapping from Python types to JSON Schema types
 # doesn't handle Union, Optional[T], or List[T] — just basic types for now
 _TYPE_MAP: dict[type, str] = {
     str: "string",

--- a/src/agentloom/tools/sandbox.py
+++ b/src/agentloom/tools/sandbox.py
@@ -65,8 +65,6 @@ class ToolSandbox:
         self._allowed_domains = {d.lower() for d in (allowed_domains or [])}
         self._max_write_bytes = max_write_bytes
 
-    # Internal helpers
-
     def _paths_for_read(self) -> list[Path]:
         return self._allowed_paths + self._readable_paths
 
@@ -87,8 +85,6 @@ class ToolSandbox:
                 continue
         return False
 
-    # Public validation API
-
     def validate_command(self, command: str) -> None:
         """Validate a shell command against the allowlist.
 
@@ -102,7 +98,6 @@ class ToolSandbox:
         if not self.enabled:
             return
 
-        # Reject shell operators before parsing — prevents chaining
         if _SHELL_OPERATOR_RE.search(command):
             raise SandboxViolationError(
                 "shell_command",
@@ -119,7 +114,6 @@ class ToolSandbox:
 
         executable = tokens[0]
 
-        # Strip path prefix: /usr/bin/echo -> echo
         executable = Path(executable).name
 
         if executable not in self._allowed_commands:
@@ -129,7 +123,6 @@ class ToolSandbox:
                 f"Allowed: {sorted(self._allowed_commands) or '(none)'}",
             )
 
-        # Validate absolute-path arguments against all allowed dirs
         all_paths = self._all_paths()
         if all_paths:
             for token in tokens[1:]:

--- a/tests/core/test_engine_integration.py
+++ b/tests/core/test_engine_integration.py
@@ -21,9 +21,8 @@ from agentloom.providers.gateway import ProviderGateway
 from agentloom.tools.registry import ToolRegistry
 from tests.conftest import MockProvider, MockTool
 
-# -- Helpers --
 
-
+# Helpers
 class FailingProvider(BaseProvider):
     """Provider that always fails."""
 
@@ -48,9 +47,7 @@ class CountingProvider(MockProvider):
         return await super().complete(**kwargs)
 
 
-# -- Basic flows --
-
-
+# Basic flows
 class TestSingleStep:
     async def test_completes_with_output(self) -> None:
         provider = MockProvider(responses={"Answer: test": "42"})
@@ -103,9 +100,7 @@ class TestSingleStep:
         assert provider.calls[0]["messages"][0]["content"] == "Hello Alice"
 
 
-# -- Parallel execution --
-
-
+# Parallel execution
 class TestParallelExecution:
     async def test_parallel_steps_all_complete(self) -> None:
         provider = MockProvider()
@@ -154,9 +149,7 @@ class TestParallelExecution:
         assert counter.call_count == 3
 
 
-# -- Router / conditional branching --
-
-
+# Router / conditional branching
 class TestRouterIntegration:
     async def test_router_activates_correct_branch(self) -> None:
         provider = MockProvider(responses={"Classify: billing issue": "billing"})
@@ -253,9 +246,7 @@ class TestRouterIntegration:
         assert result.step_results["billing"].status == StepStatus.SKIPPED
 
 
-# -- Tool integration --
-
-
+# Tool integration
 class TestToolIntegration:
     async def test_tool_step_executes(self) -> None:
         provider = MockProvider()
@@ -294,9 +285,7 @@ class TestToolIntegration:
         assert mock_tool.calls == [{"input": "test"}]
 
 
-# -- Resilience --
-
-
+# Resilience
 class TestProviderFallback:
     async def test_fallback_on_primary_failure(self) -> None:
         backup = MockProvider()
@@ -406,9 +395,7 @@ class TestRetryBehavior:
         assert result.status == WorkflowStatus.FAILED
 
 
-# -- Observer integration --
-
-
+# Observer integration
 class TestObserverIntegration:
     async def test_observer_receives_lifecycle_events(self) -> None:
         provider = MockProvider()
@@ -531,9 +518,7 @@ class TestObserverIntegration:
         assert sr.time_to_first_token_ms is None
 
 
-# -- Subworkflow integration --
-
-
+# Subworkflow integration
 class TestSubworkflowIntegration:
     async def test_inline_subworkflow(self) -> None:
         provider = MockProvider()
@@ -580,9 +565,7 @@ class TestSubworkflowIntegration:
         assert len(provider.calls) == 2
 
 
-# -- Multi-layer complex workflow --
-
-
+# Multi-layer complex workflow
 class TestComplexWorkflow:
     async def test_five_layer_workflow(self) -> None:
         """Simulates a realistic multi-layer workflow:

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -18,9 +18,8 @@ from agentloom.core.models import (
     WorkflowDefinition,
 )
 
+
 # Shared helpers
-
-
 def _linear_dag() -> DAG:
     """a -> b -> c"""
     return DAG.from_steps([("a", []), ("b", ["a"]), ("c", ["b"])])
@@ -96,8 +95,6 @@ def _mixed_type_workflow() -> WorkflowDefinition:
 
 
 # TestGraphNode
-
-
 class TestGraphNode:
     def test_construction_all_fields(self) -> None:
         node = GraphNode(
@@ -130,8 +127,6 @@ class TestGraphNode:
 
 
 # TestGraphEdge
-
-
 class TestGraphEdge:
     def test_construction_all_fields(self) -> None:
         edge = GraphEdge(source="a", target="b", label="condition")
@@ -150,8 +145,6 @@ class TestGraphEdge:
 
 
 # TestFromWorkflow
-
-
 class TestFromWorkflow:
     def test_build_from_simple_workflow(self) -> None:
         wf = _router_workflow()
@@ -195,8 +188,6 @@ class TestFromWorkflow:
 
 
 # TestFromDAG
-
-
 class TestFromDAG:
     def test_build_from_bare_dag(self) -> None:
         dag = _linear_dag()
@@ -222,8 +213,6 @@ class TestFromDAG:
 
 
 # TestProperties
-
-
 class TestProperties:
     def test_nodes_in_topological_order(self) -> None:
         dag = _linear_dag()
@@ -275,8 +264,6 @@ class TestProperties:
 
 
 # TestGetStepDefinition
-
-
 class TestGetStepDefinition:
     def test_returns_step_definition_from_workflow(self) -> None:
         wf = _router_workflow()
@@ -296,8 +283,6 @@ class TestGetStepDefinition:
 
 
 # TestAllPaths
-
-
 class TestAllPaths:
     def test_linear_chain_single_path(self) -> None:
         g = WorkflowGraph.from_dag(_linear_dag())
@@ -337,8 +322,6 @@ class TestAllPaths:
 
 
 # TestPrimePaths
-
-
 class TestPrimePaths:
     def test_linear_chain_single_prime_path(self) -> None:
         g = WorkflowGraph.from_dag(_linear_dag())
@@ -378,8 +361,6 @@ class TestPrimePaths:
 
 
 # TestCriticalPath
-
-
 class TestCriticalPath:
     def test_linear_chain_full_chain(self) -> None:
         g = WorkflowGraph.from_dag(_linear_dag())
@@ -413,8 +394,6 @@ class TestCriticalPath:
 
 
 # TestToDict
-
-
 class TestToDict:
     def test_keys_present(self) -> None:
         g = WorkflowGraph.from_dag(_linear_dag())
@@ -456,8 +435,6 @@ class TestToDict:
 
 
 # TestToDot
-
-
 class TestToDot:
     def test_contains_digraph_workflow(self) -> None:
         g = WorkflowGraph.from_dag(_linear_dag())
@@ -501,8 +478,6 @@ class TestToDot:
 
 
 # TestToPnml
-
-
 class TestToPnml:
     def test_valid_xml(self) -> None:
         g = WorkflowGraph.from_dag(_linear_dag())
@@ -544,8 +519,6 @@ class TestToPnml:
 
 
 # TestToMermaid
-
-
 class TestToMermaid:
     def test_starts_with_graph_td(self) -> None:
         g = WorkflowGraph.from_dag(_linear_dag())
@@ -591,8 +564,6 @@ class TestToMermaid:
 
 
 # TestToNetworkx
-
-
 class TestToNetworkx:
     def test_builds_digraph_when_networkx_available(self) -> None:
         nx = pytest.importorskip("networkx")
@@ -628,8 +599,6 @@ class TestToNetworkx:
 
 
 # Audit-driven edge-case tests
-
-
 class TestPrimePathsEdgeCases:
     def test_empty_graph(self) -> None:
         g = WorkflowGraph.from_dag(DAG())

--- a/tests/e2e/test_checkpoint_e2e.py
+++ b/tests/e2e/test_checkpoint_e2e.py
@@ -69,7 +69,7 @@ class TestCheckpointLifecycle:
             workflow_file = f.name
 
         with tempfile.TemporaryDirectory() as cp_dir:
-            # ── Step 1: run with checkpoint ──────────────────────────
+            # Step 1: run with checkpoint
             result = _run_cli(
                 "run",
                 workflow_file,
@@ -102,7 +102,7 @@ class TestCheckpointLifecycle:
             assert "thought" in checkpoint["state"]
             assert "answer" in checkpoint["state"]
 
-            # ── Step 2: list runs ────────────────────────────────────
+            # Step 2: list runs
             list_result = _run_cli("runs", "--checkpoint-dir", cp_dir)
             assert list_result.returncode == 0, f"runs failed: {list_result.stderr}"
             assert run_id in list_result.stdout
@@ -116,7 +116,7 @@ class TestCheckpointLifecycle:
             assert runs_data[0]["run_id"] == run_id
             assert runs_data[0]["status"] == "success"
 
-            # ── Step 3: resume (all steps done → no-op success) ──────
+            # Step 3: resume (all steps done → no-op success)
             resume_result = _run_cli(
                 "resume",
                 run_id,

--- a/tests/providers/test_gateway.py
+++ b/tests/providers/test_gateway.py
@@ -12,9 +12,8 @@ from agentloom.providers.base import BaseProvider, ProviderResponse, StreamRespo
 from agentloom.providers.gateway import ProviderGateway
 from tests.conftest import MockProvider
 
-# -- StreamResponse unit tests --
 
-
+# StreamResponse unit tests
 class TestStreamResponse:
     async def test_max_accumulated_bytes_exceeded(self) -> None:
         sr = StreamResponse(model="m", provider="p")
@@ -61,9 +60,7 @@ class TestStreamResponse:
         assert resp.finish_reason == "stop"
 
 
-# -- ProviderGateway tests --
-
-
+# ProviderGateway tests
 class MidStreamFailProvider(BaseProvider):
     """A provider that yields some chunks then fails mid-stream."""
 
@@ -135,7 +132,7 @@ class FailingProvider(BaseProvider):
 
         async def _generate() -> AsyncIterator[str]:
             raise ProviderError("failing", self._error_msg)
-            yield ""  # noqa: RET504 — unreachable but needed for async generator
+            yield ""
 
         sr._set_iterator(_generate())
         return sr

--- a/tests/steps/test_llm_call.py
+++ b/tests/steps/test_llm_call.py
@@ -14,9 +14,8 @@ from agentloom.providers.gateway import ProviderGateway
 from agentloom.steps.base import StepContext
 from agentloom.steps.llm_call import LLMCallStep
 
-# -- DotAccessDict --
 
-
+# DotAccessDict
 class TestDotAccessDict:
     def test_simple_access(self) -> None:
         d = DotAccessDict({"name": "Alice"})
@@ -58,9 +57,7 @@ class TestDotAccessDict:
         assert result == "alpha"
 
 
-# -- DotAccessList --
-
-
+# DotAccessList
 class TestDotAccessList:
     def test_int_index(self) -> None:
         dl = DotAccessList(["a", "b", "c"])
@@ -98,9 +95,7 @@ class TestDotAccessList:
         assert dl["abc"] == ""
 
 
-# -- SafeFormatDict --
-
-
+# SafeFormatDict
 class TestSafeFormatDict:
     def test_existing_key(self) -> None:
         d = SafeFormatDict(name="Alice")
@@ -116,9 +111,7 @@ class TestSafeFormatDict:
         assert result == "1 and {b}"
 
 
-# -- LLMCallStep --
-
-
+# LLMCallStep
 class TestLLMCallStep:
     @pytest.fixture
     def step(self) -> LLMCallStep:


### PR DESCRIPTION
## Summary

- Strip decorative separators, filler/obvious comments, and excess blank lines in application code (examples, scripts, src, tests). Keeps IaC-style separators in Dockerfile, docker-compose.yml, terraform/main.tf.
- Lint and format audit scripts (ruff fixes: unused noqa, E402, E741, B007; format).
- Simplify `.agentloom` gitignore to `.agentloom/` and drop the unnecessary `.gitkeep` (dir is created via `mkdir(parents=True, exist_ok=True)`).
- Align terraform observability section: remove stray asymmetric `# ---` marker after description block.

## Test plan

- [x] \`uv run pytest\` passes
- [x] \`uv run ruff check src/ tests/\` clean
- [x] \`uv run ruff format\` clean