### PR TITLE
complete mock provider cli integration (#61, #76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `agentloom replay <workflow.yaml> --recording <file.json>` subcommand — re-executes a workflow against recorded responses with no API calls (#61)
 - YAML-configured MockProvider — `provider: mock` with `responses_file`, `latency_model`, `latency_ms` fields on `WorkflowConfig` (#76)
 - Production `MockProvider` and `RecordingProvider` for deterministic replay and offline evaluation (#76)
   - `MockProvider` loads responses from a JSON file, keyed by `step_id` or SHA-256 prompt hash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- YAML-configured MockProvider — `provider: mock` with `responses_file`, `latency_model`, `latency_ms` fields on `WorkflowConfig` (#76)
 - Production `MockProvider` and `RecordingProvider` for deterministic replay and offline evaluation (#76)
   - `MockProvider` loads responses from a JSON file, keyed by `step_id` or SHA-256 prompt hash
   - Latency models: `constant`, `normal` (gaussian with seed), `replay` (uses recorded `latency_ms`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@
 - `uv run ruff format src/ tests/` — format
 - `uv run mypy src/` — strict type check
 - `uv run agentloom run examples/01_simple_qa.yaml` — run a workflow
+- `uv run agentloom replay workflow.yaml --recording rec.json` — replay from recorded responses (offline, no API key)
 - `uv run agentloom validate examples/03_router_workflow.yaml` — validate YAML
 
 ## Rules

--- a/README.md
+++ b/README.md
@@ -372,8 +372,10 @@ Record real LLM responses once, replay them offline forever — reproducible tes
 agentloom run workflow.yaml --record recordings/run1.json
 
 # Replay offline — no network, no key, no cost, byte-identical output
-agentloom run workflow.yaml --mock-responses recordings/run1.json
+agentloom replay workflow.yaml --recording recordings/run1.json
 ```
+
+Or configure the mock directly in YAML (`provider: mock` + `responses_file`) and run it with plain `agentloom run` — see [`examples/32_yaml_mock.yaml`](examples/32_yaml_mock.yaml) and [docs/testing-and-replay](https://cchinchilla-dev.github.io/agentloom/testing-and-replay/#yaml-configured-mockprovider).
 
 Responses are keyed by `step_id` or a SHA-256 hash of the messages. `MockProvider` supports three latency models (`constant`, `normal`, `replay`) for faithful performance reproduction. Replays emit Prometheus metrics (`agentloom_mock_replays_total`, `agentloom_recording_captures_total`) and a dedicated "Mock & Replay" row in the stock Grafana dashboard. See [docs/testing-and-replay](https://cchinchilla-dev.github.io/agentloom/testing-and-replay/) and [`examples/31_record_and_replay.yaml`](examples/31_record_and_replay.yaml).
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Added
 
+- **YAML-configured MockProvider** — set `provider: mock` in `WorkflowConfig` with `responses_file`, `latency_model`, and `latency_ms` fields (#76)
+    - Lets committed fixtures run via plain `agentloom run` without CLI flags
 - **Deterministic replay with `MockProvider` and `RecordingProvider`** — offline evaluation and reproducible tests (#76)
     - `MockProvider` loads pre-recorded responses from a JSON file, keyed by `step_id` or SHA-256 hash of the messages
     - Latency models: `constant`, `normal` (seeded gaussian), `replay` (uses the recorded `latency_ms`)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. The format follows [Kee
 
 ### Added
 
+- **`agentloom replay` subcommand** — re-executes a workflow against a recorded JSON file with no API calls (#61)
+    - Thin alias over `run --mock-responses` with `--lite` on by default; `--state` override supported
+    - Works end-to-end with recordings captured via `agentloom run --record`
 - **YAML-configured MockProvider** — set `provider: mock` in `WorkflowConfig` with `responses_file`, `latency_model`, and `latency_ms` fields (#76)
     - Lets committed fixtures run via plain `agentloom run` without CLI flags
 - **Deterministic replay with `MockProvider` and `RecordingProvider`** — offline evaluation and reproducible tests (#76)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -263,3 +263,35 @@ agentloom runs
 # Resume a failed or interrupted run
 agentloom resume <run_id> --lite
 ```
+
+## Testing & Replay
+
+### 31 — Record and Replay
+
+Two-step workflow used to capture real LLM responses and replay them offline.
+Run once with `--record` against a real provider, then replay any number of
+times without network or API keys.
+
+**Demonstrates:** `--record`, `--mock-responses`, `agentloom replay`.
+
+```bash
+# Capture real Anthropic responses (per-call flush; partial recordings survive crashes)
+agentloom run examples/31_record_and_replay.yaml --record recordings/byzantine.json
+
+# Replay offline — pick either form
+agentloom replay examples/31_record_and_replay.yaml --recording recordings/byzantine.json
+agentloom run examples/31_record_and_replay.yaml --mock-responses recordings/byzantine.json
+```
+
+### 32 — YAML-configured MockProvider
+
+Same workflow as 31, but with `provider: mock` and `responses_file` declared in
+YAML. Runs via plain `agentloom run` with no CLI flags — useful for committed
+fixtures and CI.
+
+**Demonstrates:** `provider: mock`, `responses_file`, `latency_model: replay`.
+
+```bash
+# Depends on the recording captured from example 31
+agentloom run examples/32_yaml_mock.yaml --lite
+```

--- a/docs/testing-and-replay.md
+++ b/docs/testing-and-replay.md
@@ -41,13 +41,32 @@ Keys are the step's `step_id` when available, or the SHA-256 hash of the seriali
 
 ## Replaying a run
 
-Point the CLI at a recorded file:
+Two equivalent ways:
 
 ```bash
+# Dedicated subcommand — observability off by default, no stream/checkpoint flags
+agentloom replay workflow.yaml --recording recordings/run1.json
+
+# Or via run --mock-responses (same effect)
 agentloom run workflow.yaml --mock-responses recordings/run1.json
 ```
 
 Every `llm_call` step resolves from the JSON. No network, no API key, no cost. Latency is simulated according to `latency_model`.
+
+### YAML-configured MockProvider
+
+You can also declare the mock provider directly in the workflow config, avoiding CLI flags entirely:
+
+```yaml
+config:
+  provider: mock
+  model: mock-model
+  responses_file: fixtures/responses.json
+  latency_model: constant   # constant | normal | replay
+  latency_ms: 0
+```
+
+Run it like any normal workflow — `agentloom run workflow.yaml`. Useful for committed fixtures and CI without plumbing flags through shell scripts.
 
 ## Latency models
 

--- a/docs/workflow-yaml.md
+++ b/docs/workflow-yaml.md
@@ -41,6 +41,9 @@ steps:                                      # at least one step required
 | `max_concurrent_steps` | `int` | `10` | Max parallel steps per layer |
 | `stream` | `bool` | `false` | Enable streaming by default |
 | `sandbox` | `object` | disabled | Security sandbox config |
+| `responses_file` | `string` | `null` | Mock provider recording path (when `provider: mock`) |
+| `latency_model` | `string` | `constant` | Mock latency mode: `constant` / `normal` / `replay` |
+| `latency_ms` | `float` | `0` | Mock provider simulated latency per call |
 
 ## Checkpointing
 

--- a/examples/31_record_and_replay.yaml
+++ b/examples/31_record_and_replay.yaml
@@ -2,9 +2,10 @@ name: record-and-replay
 version: "1.0"
 description: |
   Demonstrates deterministic replay. Run once with --record against a real
-  provider to capture responses, then replay offline forever with
-  --mock-responses. Great for CI, tests, and statistical evaluation without
-  paying per-run.
+  provider to capture responses, then replay offline forever — either via
+  `agentloom replay <file> --recording rec.json` or `agentloom run <file>
+  --mock-responses rec.json`. For a YAML-only path, see 32_yaml_mock.yaml.
+  Great for CI, tests, and statistical evaluation without paying per-run.
 
 config:
   provider: anthropic

--- a/examples/32_yaml_mock.yaml
+++ b/examples/32_yaml_mock.yaml
@@ -1,0 +1,37 @@
+name: yaml-mock
+version: "1.0"
+description: |
+  Shows how to configure MockProvider entirely from YAML, with no CLI flags.
+  Drop a recording file next to this workflow and run it with plain
+  `agentloom run`. Useful for committed fixtures and CI pipelines that
+  shouldn't know about record/replay plumbing.
+
+  Produce the recording once with:
+    agentloom run examples/31_record_and_replay.yaml --record recordings/byzantine.json
+
+config:
+  provider: mock
+  model: claude-sonnet-4-20250514
+  responses_file: recordings/byzantine.json
+  latency_model: replay   # constant | normal | replay
+  latency_ms: 0
+
+state:
+  topic: "the Byzantine Generals Problem"
+
+steps:
+  - id: explain
+    type: llm_call
+    prompt: "Explain {state.topic} in exactly two sentences."
+    output: explanation
+
+  - id: critique
+    type: llm_call
+    depends_on: [explain]
+    prompt: |
+      Here is an explanation of {state.topic}:
+
+      {state.explanation}
+
+      List one thing this explanation gets wrong or oversimplifies.
+    output: critique

--- a/src/agentloom/cli/main.py
+++ b/src/agentloom/cli/main.py
@@ -12,6 +12,7 @@ app = typer.Typer(
 
 from agentloom.cli.callback_server import callback_server  # noqa: E402
 from agentloom.cli.info import info  # noqa: E402
+from agentloom.cli.replay import replay  # noqa: E402
 from agentloom.cli.resume import resume  # noqa: E402
 from agentloom.cli.run import run  # noqa: E402
 from agentloom.cli.runs import runs  # noqa: E402
@@ -19,6 +20,7 @@ from agentloom.cli.validate import validate  # noqa: E402
 from agentloom.cli.visualize import visualize  # noqa: E402
 
 app.command("run")(run)
+app.command("replay")(replay)
 app.command("resume")(resume)
 app.command("runs")(runs)
 app.command("validate")(validate)

--- a/src/agentloom/cli/replay.py
+++ b/src/agentloom/cli/replay.py
@@ -1,0 +1,45 @@
+"""CLI command: replay a workflow from a recorded responses file.
+
+Thin alias over ``run`` that forces ``provider=mock`` and loads responses
+from the given recording file. Observability is disabled by default.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import anyio
+import typer
+
+from agentloom.cli.run import _run_async
+
+
+def replay(
+    workflow_path: Path = typer.Argument(..., help="Path to the workflow YAML file.", exists=True),
+    recording: Path = typer.Option(
+        ..., "--recording", "-r", help="Path to a recorded responses JSON file.", exists=True
+    ),
+    state: list[str] = typer.Option(
+        [], "--state", "-s", help="State variables as key=value pairs."
+    ),
+    output_json: bool = typer.Option(False, "--json", help="Output results as JSON."),
+    observability: bool = typer.Option(
+        False, "--observability", help="Enable observability (disabled by default in replay)."
+    ),
+) -> None:
+    """Replay a workflow using previously recorded LLM responses (no API calls)."""
+    anyio.run(
+        _run_async,
+        workflow_path,
+        state,
+        None,  # provider_override
+        None,  # model_override
+        None,  # budget
+        not observability,  # lite
+        output_json,
+        False,  # stream
+        False,  # checkpoint
+        ".agentloom/checkpoints",
+        recording,  # mock_responses
+        None,  # record
+    )

--- a/src/agentloom/cli/run.py
+++ b/src/agentloom/cli/run.py
@@ -124,6 +124,19 @@ async def _run_async(
             ),
             priority=0,
         )
+    elif workflow.config.provider == "mock" and record is None:
+        from agentloom.providers.mock import MockProvider
+
+        gateway.register(
+            MockProvider(
+                responses_file=workflow.config.responses_file,
+                latency_model=workflow.config.latency_model,
+                latency_ms=workflow.config.latency_ms,
+                observer=observer,
+                workflow_name=workflow.name,
+            ),
+            priority=0,
+        )
     else:
         _setup_providers(gateway, workflow.config.provider)
         if record is not None:

--- a/src/agentloom/core/models.py
+++ b/src/agentloom/core/models.py
@@ -135,6 +135,11 @@ class WorkflowConfig(BaseModel):
     stream: bool = False
     sandbox: SandboxConfig = Field(default_factory=SandboxConfig)
 
+    # MockProvider configuration (used only when provider == "mock")
+    responses_file: str | None = None
+    latency_model: Literal["constant", "normal", "replay"] = "constant"
+    latency_ms: float = 0.0
+
 
 class WorkflowDefinition(BaseModel):
     """Complete workflow definition — the top-level schema for YAML files."""

--- a/tests/cli/test_replay.py
+++ b/tests/cli/test_replay.py
@@ -1,0 +1,196 @@
+"""Tests for CLI replay command and YAML-configured MockProvider."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from agentloom.cli.main import app
+
+runner = CliRunner()
+
+SIMPLE_YAML = """\
+name: replay-test
+config:
+  provider: mock
+  model: mock-model
+state:
+  question: "What is Python?"
+steps:
+  - id: answer
+    type: llm_call
+    prompt: "Answer: {state.question}"
+    output: answer
+"""
+
+YAML_MOCK_CONFIG = """\
+name: yaml-mock-test
+config:
+  provider: mock
+  model: mock-model
+  responses_file: "{responses_file}"
+  latency_model: constant
+  latency_ms: 0
+state:
+  question: "What is Python?"
+steps:
+  - id: answer
+    type: llm_call
+    prompt: "Answer: {{state.question}}"
+    output: answer
+"""
+
+RECORDING = {
+    "answer": {
+        "content": "42",
+        "model": "mock-model",
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        "cost_usd": 0.0,
+        "latency_ms": 0.0,
+        "finish_reason": "stop",
+    }
+}
+
+
+class TestReplayCommand:
+    def test_replay_invokes_mock_provider(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            rec_path = Path(tmp) / "rec.json"
+            rec_path.write_text(json.dumps(RECORDING))
+            yaml_path = Path(tmp) / "wf.yaml"
+            yaml_path.write_text(SIMPLE_YAML)
+            with patch("agentloom.cli.run._setup_observer", return_value=None):
+                result = runner.invoke(
+                    app,
+                    ["replay", str(yaml_path), "--recording", str(rec_path)],
+                )
+        assert result.exit_code == 0, f"stdout: {result.output}"
+        assert "'answer'" in result.output
+
+    def test_replay_requires_existing_recording(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            yaml_path = Path(tmp) / "wf.yaml"
+            yaml_path.write_text(SIMPLE_YAML)
+            result = runner.invoke(
+                app,
+                ["replay", str(yaml_path), "--recording", "/tmp/does_not_exist_xyz.json"],
+            )
+        assert result.exit_code != 0
+
+
+class TestYamlMockProvider:
+    def test_workflow_config_defaults(self) -> None:
+        from agentloom.core.models import WorkflowConfig
+
+        cfg = WorkflowConfig()
+        assert cfg.responses_file is None
+        assert cfg.latency_model == "constant"
+        assert cfg.latency_ms == 0.0
+
+    def test_workflow_config_rejects_bad_latency_model(self) -> None:
+        import pytest
+        from pydantic import ValidationError
+
+        from agentloom.core.models import WorkflowConfig
+
+        with pytest.raises(ValidationError):
+            WorkflowConfig(latency_model="bogus")  # type: ignore[arg-type]
+
+    def test_yaml_latency_fields_reach_provider(self) -> None:
+        from agentloom.cli.run import _run_async
+
+        captured: dict[str, object] = {}
+
+        class _Capture:
+            def __init__(self, **kwargs: object) -> None:
+                captured.update(kwargs)
+
+            def supports_model(self, model: str) -> bool:
+                return True
+
+            async def complete(self, **kwargs: object) -> None:  # pragma: no cover
+                raise RuntimeError("not invoked")
+
+            async def close(self) -> None:
+                return None
+
+            name = "mock"
+
+        yaml_body = """\
+name: latency-test
+config:
+  provider: mock
+  model: mock-model
+  latency_model: normal
+  latency_ms: 42
+steps:
+  - id: answer
+    type: llm_call
+    prompt: "hi"
+    output: answer
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            yaml_path = Path(tmp) / "wf.yaml"
+            yaml_path.write_text(yaml_body)
+            with (
+                patch("agentloom.cli.run._setup_observer", return_value=None),
+                patch("agentloom.providers.mock.MockProvider", _Capture),
+            ):
+                import contextlib
+
+                import anyio
+
+                with contextlib.suppress(Exception):
+                    # engine will fail because _Capture.complete raises
+                    anyio.run(
+                        _run_async,
+                        yaml_path,
+                        [],
+                        None,
+                        None,
+                        None,
+                        True,
+                        False,
+                        False,
+                        False,
+                        ".agentloom/checkpoints",
+                        None,
+                        None,
+                    )
+        assert captured.get("latency_model") == "normal"
+        assert captured.get("latency_ms") == 42.0
+
+    def test_replay_with_state_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            rec_path = Path(tmp) / "rec.json"
+            rec_path.write_text(json.dumps(RECORDING))
+            yaml_path = Path(tmp) / "wf.yaml"
+            yaml_path.write_text(SIMPLE_YAML)
+            with patch("agentloom.cli.run._setup_observer", return_value=None):
+                result = runner.invoke(
+                    app,
+                    [
+                        "replay",
+                        str(yaml_path),
+                        "--recording",
+                        str(rec_path),
+                        "--state",
+                        "question=Override?",
+                    ],
+                )
+        assert result.exit_code == 0, f"stdout: {result.output}"
+
+    def test_yaml_mock_provider_uses_responses_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            rec_path = Path(tmp) / "rec.json"
+            rec_path.write_text(json.dumps(RECORDING))
+            yaml_path = Path(tmp) / "wf.yaml"
+            yaml_path.write_text(YAML_MOCK_CONFIG.format(responses_file=str(rec_path)))
+            with patch("agentloom.cli.run._setup_observer", return_value=None):
+                result = runner.invoke(app, ["run", str(yaml_path), "--lite"])
+        assert result.exit_code == 0, f"stdout: {result.output}"
+        assert "'answer'" in result.output


### PR DESCRIPTION
## What

Closes the two spec gaps left by PR #102 so MockProvider is fully reachable from YAML and the CLI:

- **`agentloom replay <workflow.yaml> --recording <file.json>`** — thin alias over `run --mock-responses` with `--lite` on by default and `--state` overrides supported
- **YAML-configured MockProvider** — `provider: mock` + `responses_file` / `latency_model` / `latency_ms` on `WorkflowConfig`, runnable with plain `agentloom run`
- New example `examples/32_yaml_mock.yaml` paired with the existing `31_record_and_replay.yaml`
- Docs refreshed: README, testing-and-replay, workflow-yaml, examples, CHANGELOG, CLAUDE.md

## Why

`MockProvider` shipped in #102 but was only reachable via programmatic use or the `--mock-responses` flag — #76 asked for YAML config and #61 asked for a dedicated `replay` subcommand. Both paths matter for CI and committed fixtures: YAML keeps test harnesses flag-free, and `replay` makes record→replay symmetric at the CLI.

## Testing

- [x] `uv run pytest` — 862 passed
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format src/ tests/` — clean
- [x] 7 new tests in `tests/cli/test_replay.py` covering both paths
- [x] End-to-end with **real Claude Sonnet 4** in CLI / Docker / Kubernetes — record (~6.1s, 269 tok, \$0.0026) vs replay (~0.7ms, same tokens / cost, byte-identical final state)
- [x] `latency_model: replay` reproduces recorded latency (6133ms → 6133ms) in example 32

## Notes

- `run.py` only takes the new YAML-mock branch when `record is None`, so the existing `--record` path still flows through `_setup_providers` (keeps the #102 test green)
- Pre-existing: the engine doesn't thread `step_id` into `gateway.complete()`, so CLI replays match by prompt hash — out of scope here, worth a follow-up issue

Closes #61
Closes #76