### PR TITLE
require pr flow in release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -39,7 +39,7 @@ So the commit message prefix (`bump version to`) is load-bearing. Don't paraphra
 
 6. **Open PR** — ask authorization first. Title matches the commit (`bump version to <X.Y.Z>`). Body: link the `## [X.Y.Z]` section of CHANGELOG.md and summarize highlights. Never push directly to `main`, never use admin bypass.
 
-7. **Wait for checks + merge** — all required status checks must pass. Merge with a merge commit or squash (whichever the repo uses). Once the bump commit lands on `main`:
+7. **Wait for checks + squash-merge** — all required status checks must pass. **Squash-merge only** (this repo's convention). When completing the squash merge, override the default `Merge pull request ...` title so the resulting commit on `main` starts with exactly `bump version to <X.Y.Z>` — the `auto-tag.yml` workflow greps that prefix and will skip tagging otherwise. Once that squash commit lands on `main`:
    - Auto Tag creates `v<X.Y.Z>`.
    - Release builds + publishes. Watch: `gh run list --limit 5`.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -7,7 +7,9 @@ Prepare a release. `$ARGUMENTS` is the bump type: `patch` (default), `minor`, `m
 
 ## How this repo ships
 
-CI does the tagging and publishing. The human-side job is just: bump version + update changelog + commit to `main` with the magic message.
+Releases go through a **pull request**, same as any other change. No direct pushes to `main`, no admin bypass — even for version bumps. This keeps the audit trail clean and matches the historical pattern (see PRs #18, #32, #36, #92).
+
+CI does the tagging and publishing once the PR merges:
 
 - `.github/workflows/auto-tag.yml` watches `main` for commits whose message starts with `bump version to` → reads the version from `pyproject.toml` and pushes `v<X.Y.Z>`.
 - `.github/workflows/release.yml` triggers on the tag push → builds the wheel, creates a GitHub Release with auto-generated notes, publishes to PyPI via OIDC.
@@ -33,10 +35,12 @@ So the commit message prefix (`bump version to`) is load-bearing. Don't paraphra
    - `version` in `pyproject.toml`
    - `__version__` in `src/agentloom/__init__.py`
 
-5. **Commit** — message **must** start with `bump version to <X.Y.Z>`. Follow `/commit` rules otherwise (no scopes, no Co-Authored-By). Do **not** run `git tag` locally — the workflow creates it.
+5. **Branch + commit** — create `release/<X.Y.Z>` from an up-to-date `main`. Commit message **must** start with `bump version to <X.Y.Z>`. Follow `/commit` rules otherwise (no scopes, no Co-Authored-By). Do **not** run `git tag` locally — the workflow creates it on merge.
 
-6. **Push to main** — ask authorization first. Once pushed:
+6. **Open PR** — ask authorization first. Title matches the commit (`bump version to <X.Y.Z>`). Body: link the `## [X.Y.Z]` section of CHANGELOG.md and summarize highlights. Never push directly to `main`, never use admin bypass.
+
+7. **Wait for checks + merge** — all required status checks must pass. Merge with a merge commit or squash (whichever the repo uses). Once the bump commit lands on `main`:
    - Auto Tag creates `v<X.Y.Z>`.
-   - Release builds + publishes. Watch: `gh run list --limit 3`.
+   - Release builds + publishes. Watch: `gh run list --limit 5`.
 
-7. **Post-release** — report tag, GitHub Release URL, and PyPI job status. If auto-tag/release fails, inspect with `/ci-status` instead of trying to recover by hand.
+8. **Post-release** — report PR URL, tag, GitHub Release URL, and PyPI job status. If auto-tag/release fails, inspect with `/ci-status` instead of trying to recover by hand.


### PR DESCRIPTION
## Summary

Update `/release` skill so version bumps go through a pull request instead of pushing directly to `main`.

## Why

While cutting v0.4.0 today, the skill instructed a direct push to `main`. GitHub accepted it by bypassing the branch protection rule (`Bypassed rule violations for refs/heads/main`), which is inconsistent with every previous release — #18 (v0.1.1), #32 (v0.1.2), #36 (v0.2.0), #92 (v0.3.0) — all went through PR.

The bypass also sidesteps required status checks, so a broken bump could tag + publish before CI catches it. The v0.4.0 release workflow itself had a bug (checkout wiping the dist/ directory before softprops could attach it — fixed in cb038df) that would have been harder to catch this way.

## Changes

- `.claude/skills/release/SKILL.md` — step 5 now creates `release/<X.Y.Z>` branch, step 6 opens a PR instead of pushing to main, step 7 waits for checks + merge, step 8 reports PR URL alongside tag/release/PyPI.
- Header note added stating releases go through PR with no admin bypass, citing the historical PRs.

Auto-tag and release workflows are unchanged — they still trigger on `bump version to` landing on `main`, whether via merge or direct push.

## Test plan

- [x] Next release (0.4.1+) will follow the new flow