### PR TITLE
add roadmap skill and enforce lockfile sync in pr

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -7,7 +7,9 @@ Open a PR for the current branch.
 
 ## Process
 
-1. **Pre-flight** — run `/check`. Warn (don't block); the user may want a draft anyway.
+1. **Pre-flight**
+   - Run `/check`. Warn (don't block); the user may want a draft anyway.
+   - Verify the lockfile is in sync: `uv lock --check`. If it fails, the lock drifted from `pyproject.toml` (common after a `version` bump or a dependency edit without re-locking). Run `uv lock` to refresh, stage `uv.lock`, and include it — as its own commit when it's housekeeping, folded into the feature commit when it's a direct consequence of a dependency change in the same branch. A stale lock causes CI reproducibility failures downstream, so do not skip.
 
 2. **Gather context**
    - `git log main..HEAD --oneline`

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -22,25 +22,46 @@ So the commit message prefix (`bump version to`) is load-bearing. Don't paraphra
    - Read current from `pyproject.toml` and `src/agentloom/__init__.py`.
    - Compute new version per semver.
 
-2. **Pre-flight** — run `/check`. Abort on any failure. Also abort if `git status` is dirty.
+2. **Roadmap validation** — if a planning issue exists for this version, validate it's complete:
 
-3. **CHANGELOG** — Keep a Changelog convention already used in the repo:
+   ```bash
+   ROADMAP=$(gh issue list --label release --search "ship <X.Y.Z> in:title" --state all --json number -q '.[0].number')
+   ```
+
+   If `$ROADMAP` is non-empty:
+   - Fetch its body: `gh issue view $ROADMAP --json body -q .body`
+   - Extract all `#NNN` references from task-list items.
+   - For each, check state via `gh issue view <num> --json state -q .state`.
+   - If any referenced issue is still OPEN, **stop** and report which are unfinished. Options:
+     - Close them first.
+     - Demote to the next version (edit the roadmap body, move to the "deferred" section).
+     - Explicitly override (ask the user) if the release ships intentionally incomplete.
+
+   Skip this step for patch releases (minor cleanups, hotfixes) — those don't need a roadmap. Skip also when no matching roadmap issue is found.
+
+3. **Pre-flight** — run `/check`. Abort on any failure. Also abort if `git status` is dirty.
+
+4. **CHANGELOG** — Keep a Changelog convention already used in the repo:
    - An `## [Unreleased]` section accumulates `### Added` / `### Changed` / `### Fixed` / `### Removed` entries during development.
    - On release, **rename** `## [Unreleased]` to `## [<version>] - YYYY-MM-DD` (not prepend — rename in place).
    - Insert a fresh empty `## [Unreleased]` at the top for future work.
    - Do not rewrite or regroup existing entries. Do not auto-generate from `git log`; Unreleased is the source of truth.
    - Sync `docs/changelog.md` if it mirrors `CHANGELOG.md`.
 
-4. **Bump**
+5. **Bump**
    - `version` in `pyproject.toml`
    - `__version__` in `src/agentloom/__init__.py`
 
-5. **Branch + commit** — create `release/<X.Y.Z>` from an up-to-date `main`. Commit message **must** start with `bump version to <X.Y.Z>`. Follow `/commit` rules otherwise (no scopes, no Co-Authored-By). Do **not** run `git tag` locally — the workflow creates it on merge.
+6. **Branch + commit** — create `release/<X.Y.Z>` from an up-to-date `main`. Commit message **must** start with `bump version to <X.Y.Z>`. Follow `/commit` rules otherwise (no scopes, no Co-Authored-By). Do **not** run `git tag` locally — the workflow creates it on merge.
 
-6. **Open PR** — ask authorization first. Title matches the commit (`bump version to <X.Y.Z>`). Body: link the `## [X.Y.Z]` section of CHANGELOG.md and summarize highlights. Never push directly to `main`, never use admin bypass.
+7. **Open PR** — ask authorization first. Title matches the commit (`bump version to <X.Y.Z>`). Body includes:
+   - Link to the `## [X.Y.Z]` section of CHANGELOG.md and summary highlights.
+   - If a roadmap issue exists (from step 2), append `Closes #<roadmap>` so merging the release closes the planning issue automatically.
 
-7. **Wait for checks + squash-merge** — all required status checks must pass. **Squash-merge only** (this repo's convention). When completing the squash merge, override the default `Merge pull request ...` title so the resulting commit on `main` starts with exactly `bump version to <X.Y.Z>` — the `auto-tag.yml` workflow greps that prefix and will skip tagging otherwise. Once that squash commit lands on `main`:
+   Never push directly to `main`, never use admin bypass.
+
+8. **Wait for checks + squash-merge** — all required status checks must pass. **Squash-merge only** (this repo's convention). When completing the squash merge, override the default `Merge pull request ...` title so the resulting commit on `main` starts with exactly `bump version to <X.Y.Z>` — the `auto-tag.yml` workflow greps that prefix and will skip tagging otherwise. Once that squash commit lands on `main`:
    - Auto Tag creates `v<X.Y.Z>`.
    - Release builds + publishes. Watch: `gh run list --limit 5`.
 
-8. **Post-release** — report PR URL, tag, GitHub Release URL, and PyPI job status. If auto-tag/release fails, inspect with `/ci-status` instead of trying to recover by hand.
+9. **Post-release** — report PR URL, tag, GitHub Release URL, and PyPI job status. If auto-tag/release fails, inspect with `/ci-status` instead of trying to recover by hand. If a roadmap issue was referenced, confirm it closed automatically via the `Closes #NNN` in the merged PR.

--- a/.claude/skills/roadmap/SKILL.md
+++ b/.claude/skills/roadmap/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: roadmap
+description: Create a release-tracking issue that organizes open issues into a phased roadmap. Pass a target version (e.g., `0.5.0`) to scope the plan.
+---
+
+Create a release-tracking issue (a "roadmap") that organizes open issues into a phased implementation plan. Matches the pattern of #133 (0.5.0 roadmap).
+
+`$ARGUMENTS` is the target version (e.g., `0.5.0`, `1.0.0`). If missing, ask.
+
+## When to use this
+
+For minor or major releases with coordinated scope — multiple issues with interdependencies, parallelization decisions worth communicating, or deferred items that need to be explicitly listed so they're not forgotten. Skip for patch releases (hotfixes, small cleanups); those ship directly from the Unreleased CHANGELOG section via `/release`.
+
+## Process
+
+1. **Scope conversation** — ask:
+   - What drives this release? (security fixes, new capabilities, both)
+   - What is explicitly in-scope vs. deferred?
+   - Critical path driver if any (e.g., a downstream project that needs specific features)
+
+2. **Inventory** — run `gh issue list --state open --limit 200 --json number,title,labels`. Read bodies of non-trivial issues to understand cross-refs. Flag closed issues still referenced in open work.
+
+3. **Phase structure** — organize issues by:
+   - Criticality (security/correctness first)
+   - Dependencies (foundations before features)
+   - Parallelizability (independent work batched)
+   - User-visible outcomes (what each phase unlocks)
+
+   Typical shape:
+   - Phase 0: bug-fix sweep, correctness
+   - Phase 1: internal refactor (only if required to enable later phases)
+   - Phase 2: observability / schema foundation
+   - Phase 3+: feature waves
+   - Last phase: testing infrastructure
+
+4. **Draft** — follow the body format of #133:
+   - `### Description` with scope drivers and version-jump justification
+   - `### How to use this issue` explaining the task-list convention
+   - `## Phase N — <title>` per phase with rationale, task list of `- [ ] #NNN …`, parallelization notes
+   - `## Cross-phase dependency map` in ASCII
+   - `## What is deliberately not in <version>` with deferred issues grouped by category
+   - `## What <version> unlocks` with 3–5 concrete outcomes
+   - `## Issue inventory` table with per-phase counts
+   - `## Notes` — living document caveat
+
+   GitHub renders `- [ ] #NNN` as tracked tasks; use that syntax for every child reference.
+
+   **Formatting constraints:**
+   - No emojis, no colored markers (red/yellow/green dots). Plain text only.
+   - ASCII arrows (`->`, `|`, `+`) in dependency maps, not unicode arrows.
+   - Title format: `ship <version>: <short description>` — brief, lowercase imperative.
+
+5. **Confirm** — show the full draft. Iterate on phase membership, deferred items, outcomes before creating.
+
+6. **Create** — `gh issue create --title "ship <version>: …" --body-file /tmp/roadmap.md --label "release,enhancement"`. Return the issue URL.
+
+## Notes
+
+- The planning issue is a living document — editable after creation as scope clarifies.
+- Task-list checkboxes auto-update when child issues close; progress aggregates at the top of the issue.
+- `/release` references this issue for pre-flight validation: all referenced sub-tasks must be closed (or explicitly demoted from scope) before cutting the release.

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -39,7 +39,7 @@ engineering task that Claude Code executes on demand:
 | [`pr`](.claude/skills/pr/) | Create pull requests with auto-generated description and label suggestions |
 | [`release`](.claude/skills/release/) | Version bump, changelog generation, tagging, and push |
 | [`review`](.claude/skills/review/) | Review staged/unstaged changes for bugs, style drift, and missing coverage |
-| [`roadmap`](.claude/skills/roadmap/) | Create a release-tracking issue that organises open issues into a phased roadmap |
+| [`roadmap`](.claude/skills/roadmap/) | Create a release-tracking issue that organizes open issues into a phased roadmap |
 
 ### GitHub Copilot (GitHub / Microsoft)
 
@@ -125,10 +125,10 @@ Review findings appear in the git history as *"address review"* or
 All AI-generated code passes through multiple verification layers before
 reaching the main branch:
 
-- **Automated quality gates** — 860+ tests (including end-to-end tests with
-  Ollama running in CI), `ruff` linting, `mypy` type checking, executed on
-  every commit via the `check` skill and CI pipeline (9 GitHub Actions
-  workflows).
+- **Automated quality gates** — a comprehensive test suite (including
+  end-to-end tests with Ollama running in CI), `ruff` linting, `mypy` type
+  checking, executed on every commit via the `check` skill and CI pipeline
+  (9 GitHub Actions workflows).
 - **Independent AI code review** — GitHub Copilot (a different model from the
   one used for generation) reviews every pull request against project-specific
   standards, avoiding single-model bias.

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -39,6 +39,7 @@ engineering task that Claude Code executes on demand:
 | [`pr`](.claude/skills/pr/) | Create pull requests with auto-generated description and label suggestions |
 | [`release`](.claude/skills/release/) | Version bump, changelog generation, tagging, and push |
 | [`review`](.claude/skills/review/) | Review staged/unstaged changes for bugs, style drift, and missing coverage |
+| [`roadmap`](.claude/skills/roadmap/) | Create a release-tracking issue that organises open issues into a phased roadmap |
 
 ### GitHub Copilot (GitHub / Microsoft)
 
@@ -124,7 +125,7 @@ Review findings appear in the git history as *"address review"* or
 All AI-generated code passes through multiple verification layers before
 reaching the main branch:
 
-- **Automated quality gates** — 740+ tests (including end-to-end tests with
+- **Automated quality gates** — 860+ tests (including end-to-end tests with
   Ollama running in CI), `ruff` linting, `mypy` type checking, executed on
   every commit via the `check` skill and CI pipeline (9 GitHub Actions
   workflows).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Build & test
 - `uv sync --group dev` — install (add `--all-extras` for observability)
-- `uv run pytest` — tests (392, ~5s)
+- `uv run pytest` — tests (~5s)
 - `uv run ruff check src/ tests/` — lint
 - `uv run ruff format src/ tests/` — format
 - `uv run mypy src/` — strict type check

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agentloom"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- Add `roadmap` skill for release-tracking issues organised into phased plans, following the pattern of #133.
- Extend `release` skill with roadmap validation: ensures all referenced sub-tasks are closed before cutting the release, and appends `Closes #<roadmap>` in the release PR body.
- Extend `pr` skill pre-flight with `uv lock --check` so a stale lockfile stops the PR flow.
- Resync `uv.lock` with the 0.4.0 bump.
- Update `ATTRIBUTION.md` with the new skill row and current test count (860+).

## Test plan

- [x] `uv lock --check` clean
- [x] `roadmap` skill registered and visible in the skill list