### PR TITLE
docs(meta): align attribution, skills and conventions with agentanvil

### DIFF
--- a/.claude/skills/analyze/SKILL.md
+++ b/.claude/skills/analyze/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: analyze
-description: Deep analysis of current changes before committing. Goes beyond lint — catches logic bugs, missing error handling, and architectural issues.
+description: Deep analysis of current changes before committing. Goes beyond lint — catches logic bugs, architectural violations, security, and performance issues.
 ---
 
 Analyze the current working tree changes for issues that static tools miss.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -15,10 +15,17 @@ Open a PR for the current branch.
    - `git diff main...HEAD` — read the actual diff
    - Look at the last 3–5 merged PRs for title/label conventions: `gh pr list --state merged --limit 5 --json number,title,labels`
 
-3. **Title**
-   - Brief lowercase imperative. No `feat:`/`fix:`/`chore:` scopes unless the existing log already uses them.
-   - If the PR closes an issue, append `(#<issue>)` — e.g. `add webhook notifications for approval gates (#42)`.
-   - <70 chars.
+3. **Title** — Conventional Commits with scope (matches the commit-message convention enforced in `CLAUDE.md` / `CONTRIBUTING.md`):
+
+   ```
+   <type>(<scope>): <imperative lowercase description>
+   ```
+
+   - Types: `feat`, `fix`, `chore`, `ci`, `test`, `docs`, `refactor`, `perf`, `build`, `style`.
+   - Common scopes: `core`, `cli`, `providers`, `observability`, `steps`, `resilience`, `tools`, `webhooks`, `checkpointing`, `record-replay`, `release`, `deps`, `version`, `meta`, `examples`, `infrastructure`. Pick the most representative scope of the PR — for cross-cutting work, `meta` (docs/skills) or the dominant area.
+   - The PR title becomes the squash-merge commit on `main`, so consistency with the commit-message style matters.
+   - If the PR closes an issue, append `(#<issue>)` — e.g. `feat(webhooks): add approval-gate notifications (#42)`.
+   - Under 72 chars.
 
 4. **Body** — pick the format by PR size:
 
@@ -62,7 +69,7 @@ Open a PR for the current branch.
 
    No emojis.
 
-5. **Labels** — suggest based on changed paths; mirror labels from recent similar PRs. Common: `core`, `cli`, `providers`, `observability`, `infrastructure`, `e2e`, `enhancement`.
+5. **Labels** — `pr-labeler` auto-applies labels from `.github/labeler.yml` based on changed paths (`core`, `cli`, `providers`, `observability`, `resilience`, `infrastructure`, `ci`, `dependencies`, `release`). Add general categories (`enhancement`, `bug`, `breaking`, `e2e`) explicitly via `--label` because the labeler does not infer them from paths.
 
 6. **Push** (ask authorization first)
    - New branch: `git push --set-upstream origin <branch>`

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: Review staged or unstaged changes before committing. Catches bugs, style issues, and missing tests.
+description: Review staged or unstaged changes before committing. Catches bugs, style drift, and missing coverage.
 ---
 
 Review the current changes in the working tree:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -15,14 +15,15 @@ AgentLoom is a deterministic LLM workflow orchestrator. Python 3.11+, async (any
 
 ## Style
 
-- Commit messages: short imperative phrase, no body, lowercase.
-- Squash merge only.
+- **Commit messages**: Conventional-Commits with scope (`feat(providers): …`, `fix(core): …`, `chore(release): …`). Imperative, lowercase after the colon, no body unless explicitly required. Types: `feat`, `fix`, `chore`, `ci`, `test`, `docs`, `refactor`, `perf`, `build`, `style`. Common scopes: `core`, `cli`, `providers`, `observability`, `steps`, `resilience`, `tools`, `webhooks`, `checkpointing`, `record-replay`, `release`, `deps`, `version`, `meta`, `examples`, `infrastructure`. The PR title becomes the squash-merge commit on `main`, so the same convention applies to PR titles.
+- **Versions**: when bumping the version, update **both** `pyproject.toml` and `CHANGELOG.md` in the same commit. The `version-linearity` CI job fails when they disagree.
+- **Squash merge only.**
+- **`from __future__ import annotations`** at the top of every Python module that uses type hints.
 - Ruff for lint and format (config in `pyproject.toml`).
 - mypy strict mode.
 
 ## Known limitations (don't flag these)
 
-- `steps/llm_call.py` uses sync `state.state` in async context (FIXME exists, fixing breaks step interface).
 - `steps/registry.py` uses lazy imports inside `create_default_registry()` to avoid circular imports.
-- Built-in shell/file tools have no sandboxing (documented in CHANGELOG as known limitation).
-- Router expressions use `eval()` on AST-validated input (trusted YAML from developer, not user input).
+- Pricing table in `providers/pricing.yaml` is the source of truth — code reads it via `load_pricing()`.
+- Router expressions use AST-validated `eval()` on a hardened sandbox (#104 hardening); trusted YAML, not user input.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -35,5 +35,20 @@ ci:
       - any-glob-to-any-file:
           - .github/workflows/**
 
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - pyproject.toml
+          - uv.lock
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - README.md
+          - CHANGELOG.md
+          - CONTRIBUTING.md
+          - ATTRIBUTION.md
+
 release:
   - head-branch: ['^release\/']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: actions/setup-python@42375524f32ea8e73939f9a90c76bbce4f7be2d2  # v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.11"
       - run: python scripts/check_version_linearity.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,16 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  version-linearity:
+    name: Version linearity (pyproject ↔ CHANGELOG)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python scripts/check_version_linearity.py
+
   manifests:
     name: Validate K8s manifests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@42375524f32ea8e73939f9a90c76bbce4f7be2d2  # v5
         with:
           python-version: "3.11"
       - run: python scripts/check_version_linearity.py

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,7 +1,7 @@
 # AI-assisted development
 
 **Last updated:** 2026-04-28
-**Applies to:** agentloom up to 0.5.0
+**Applies to:** agentloom up to 0.4.0
 
 This project is built with AI-assisted tooling. This document describes which
 tools were used, how the work was split between human and AI, and what was

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,18 +1,25 @@
-# AI Attribution
+# AI-assisted development
 
-This project is built with AI-assisted tooling as part of a standard 2026
-software-engineering workflow — the same tools and practices the author uses
-professionally in industry.
+**Last updated:** 2026-04-28
+**Applies to:** agentloom up to 0.5.0
+
+This project is built with AI-assisted tooling. This document describes which
+tools were used, how the work was split between human and AI, and what was
+done to keep the result correct.
+
+The maintainer is accountable for all code, tests, documentation, and design
+decisions in this repository, whether or not they were produced with AI
+assistance. AI tools do not hold authorship of this project.
 
 ---
 
 ## Scope of AI assistance
 
-AI tools were used for software engineering tasks: code generation, test
+AI tools were used for software-engineering tasks: code generation, test
 scaffolding, documentation drafting, code review, and release automation.
 
-All architectural decisions, system design, component boundaries, and API
-design are the author's own work.
+Architectural decisions, system design, component boundaries, and API design
+are the maintainer's own work.
 
 ---
 
@@ -31,14 +38,17 @@ engineering task that Claude Code executes on demand:
 | Skill | Purpose |
 |---|---|
 | [`analyze`](.claude/skills/analyze/) | Deep pre-commit analysis: logic bugs, architectural violations, security, performance |
-| [`check`](.claude/skills/check/) | Full quality gate: tests, lint (`ruff`), type check (`mypy`) |
+| [`check`](.claude/skills/check/) | Full quality gate: format, lint (`ruff`), tests, type check (`mypy`) |
 | [`ci-status`](.claude/skills/ci-status/) | Inspect GitHub Actions runs, fetch logs, and suggest fixes on failure |
+| [`commit`](.claude/skills/commit/) | Stage and commit changes following the project's observed flow |
+| [`coverage`](.claude/skills/coverage/) | Raise patch coverage above threshold with real edge cases |
 | [`debug-workflow`](.claude/skills/debug-workflow/) | Validate workflow YAML, trace execution order, simulate state flow |
 | [`gen-tests`](.claude/skills/gen-tests/) | Generate tests targeting edge cases and failure modes |
 | [`issue`](.claude/skills/issue/) | Create, view, or triage GitHub issues from the terminal |
 | [`pr`](.claude/skills/pr/) | Create pull requests with auto-generated description and label suggestions |
 | [`release`](.claude/skills/release/) | Version bump, changelog generation, tagging, and push |
 | [`review`](.claude/skills/review/) | Review staged/unstaged changes for bugs, style drift, and missing coverage |
+| [`roadmap`](.claude/skills/roadmap/) | Create release-tracking issue organising open issues into a phased plan |
 
 ### GitHub Copilot (GitHub / Microsoft)
 
@@ -47,6 +57,17 @@ Project-specific review rules are defined in
 [`.github/copilot-instructions.md`](.github/copilot-instructions.md).
 Review findings appear in the git history as *"address review"* or
 *"fix review findings"* follow-up commits.
+
+---
+
+## Models used
+
+| Tool | Model family | Period |
+|---|---|---|
+| Claude Code | Anthropic Claude — Sonnet 4.5 / 4.6 and Opus 4.6 / 4.7 | 2025 – present |
+| GitHub Copilot review | GitHub's current review model | 2025 – present |
+
+Model versions have changed over time as vendors released successors.
 
 ---
 
@@ -85,64 +106,117 @@ Review findings appear in the git history as *"address review"* or
                               Production
 ```
 
-1. **Scope** — Features are designed and scoped by the author.  GitHub issues
-   are created in batches via the `issue` skill from human-defined
+1. **Scope** — Features are designed and scoped by the maintainer. GitHub
+   issues are created in batches via the `issue` skill from human-defined
    specifications and roadmap priorities.
-2. **Plan** — Before writing code, the author and AI collaborate on an
+2. **Plan** — Before writing code, maintainer and AI collaborate on an
    implementation plan: component structure, API surface, error handling
-   strategy, and test approach.  The author drives the technical decisions
-   and validates the final plan.
+   strategy, and test approach. Technical decisions are driven by the
+   maintainer.
 3. **Implement** — Feature branches are developed with Claude Code as coding
    assistant, using the skills above for continuous quality assurance.
-4. **Test** — Each feature is tested hands-on: running workflows end-to-end,
-   verifying CLI behaviour, inspecting provider responses, and validating
-   observability output (traces, metrics, dashboards).
+4. **Test** — Each feature is tested hands-on: workflow YAML round-trips,
+   CLI flows (`run`, `replay`, `validate`, `resume`, `history`), provider
+   integrations against real APIs (OpenAI, Anthropic, Google, Ollama), and
+   observability output (OTel traces, metrics, dashboards) in local
+   Kubernetes (kind) and Docker.
 5. **Review** — Pull requests are reviewed by GitHub Copilot against
-   project-specific standards.  Feedback is addressed before merging.
+   project-specific standards. Feedback is addressed before merging.
 6. **Ship** — Releases are prepared with the `release` skill and validated
    through the CI pipeline.
 
 ---
 
-## Human contribution
+## How the work is split
 
-| Area | Activities |
-|---|---|
-| **Architecture and design** | Technology choices, system architecture, component boundaries, API design |
-| **Specification** | Feature definition, acceptance criteria, roadmap prioritisation |
-| **Functional testing** | End-to-end workflow execution, CLI verification, provider response validation, observability output inspection |
-| **Exploratory testing** | Edge cases, error scenarios, failure modes: circuit breaker recovery, budget exhaustion, sandbox violations, concurrent state access |
-| **Infrastructure validation** | Local Kubernetes deployment, Helm chart verification, Docker builds, ArgoCD sync testing |
-| **Code review and judgement** | Final review of AI-generated code, merge decisions, architectural sign-off |
-| **Debugging** | Bug triage, root cause analysis, resolution of issues found during testing |
-| **AI tooling curation** | Project rules for Copilot and Claude Code, skill definitions, prompt engineering |
+Approximate, qualitative:
+
+| Area | Predominantly | Notes |
+|---|---|---|
+| Architecture, module boundaries, public API | Human | AI used as sounding board and implementation partner. |
+| Implementation (engine, providers, steps, observability, resilience, record/replay) | AI-assisted, human-reviewed | Generated and iterated under maintainer direction; merged after human review and CI. |
+| Test suite (unit, integration, contract suites, e2e Ollama) | AI-assisted, human-curated | Edge cases and failure modes added by the maintainer during exploratory testing. |
+| Documentation (README, MkDocs site, examples, CHANGELOG, deployment) | AI-drafted, human-edited | Structure and framing set by the maintainer. |
+| `CLAUDE.md`, skill definitions, Copilot instructions | Predominantly human | These govern how AI is used. |
+| Infrastructure (Dockerfile, Helm chart, Kustomize overlays, ArgoCD, Grafana dashboards) | AI-assisted, human-validated | Validated against a local kind cluster before merge. |
+| Debugging root-cause analysis | Human-led | AI used for log inspection and hypothesis generation; root-cause calls by the maintainer. |
+
+Line-level attribution is not tracked.
 
 ---
 
-## Verification and quality assurance
+## Verification
 
-All AI-generated code passes through multiple verification layers before
-reaching the main branch:
+AI-generated code passes through multiple layers before reaching `main`:
 
-- **Automated quality gates** — 740+ tests (including end-to-end tests with
-  Ollama running in CI), `ruff` linting, `mypy` type checking, executed on
-  every commit via the `check` skill and CI pipeline (9 GitHub Actions
-  workflows).
-- **Independent AI code review** — GitHub Copilot (a different model from the
-  one used for generation) reviews every pull request against project-specific
-  standards, avoiding single-model bias.
-- **Human review** — The author reviews all generated code for correctness,
-  design coherence, and alignment with the project's architectural goals
-  before merging.
-- **Hands-on validation** — Features are tested manually: CLI workflows,
-  provider integrations, Kubernetes deployments, and observability pipelines
-  are exercised end-to-end.
+- **Automated quality gates** — pytest suite (unit + integration + e2e
+  Ollama), `ruff` lint, `mypy --strict` type check, `version-linearity`
+  gate (`pyproject.toml` ↔ `CHANGELOG.md`). Run on every commit via the
+  `check` skill and the CI pipeline (9 GitHub Actions workflows: `ci`,
+  `auto-tag`, `release`, `labels`, `pr-labeler`, `stale`, `docker`,
+  `docs`, `e2e-ollama`).
+- **Independent AI code review** — GitHub Copilot (different vendor and
+  model from the one used for generation) reviews every pull request
+  against project-specific standards.
+- **Human review** — The maintainer reviews all generated code for
+  correctness and design coherence before merging.
+- **Hands-on validation** — CLI workflows (`agentloom run`, `replay`,
+  `validate`, `resume`, `history`), provider integrations against real
+  APIs, Kubernetes deployments via Helm and Kustomize, OTel traces in
+  Jaeger and metrics in Grafana — all exercised end-to-end.
+
+### Shared blind spots
+
+When AI generates both production code and tests, both can miss the same
+failure mode. This project treats that as a real risk and mitigates it three
+ways:
+
+1. **Hands-on exploratory testing by the maintainer** for conditions AI
+   rarely covers unprompted — concurrent flush in record/replay, hash-key
+   collision avoidance under provider parameter changes, atomic-rename on
+   partial writes, circuit-breaker state transitions under load, sandbox
+   bypass attempts, reasoning-token cost propagation, multi-turn
+   tool-calling loops.
+2. **Integration tests against real components** — `respx` per provider
+   with realistic vendor-shaped payloads (OpenAI, Anthropic, Google, Ollama),
+   Ollama running in CI for the `e2e-ollama` job, kind cluster smokes for
+   Helm and Kustomize validation, real-API smoke matrix (OpenAI + Anthropic
+   + Google) against CLI, Docker, and Kubernetes before each release.
+3. **Code review by a different vendor's model** — GitHub Copilot reviews
+   code generated via Anthropic Claude, and vice-versa for review
+   suggestions.
+
+The risk is reduced, not eliminated.
 
 ---
 
 ## Traceability
 
-The complete development history is publicly available in this repository:
-issues, pull requests, commits, and CI runs.  Every change is traceable to a
-specific issue and pull request, providing full transparency into how each
-feature was developed.
+Full development history is public: issues, pull requests, commits, CI runs,
+releases. Every change links back to an issue and a pull request.
+
+The rules that govern AI behaviour in this project are themselves versioned:
+
+- [`.claude/skills/`](.claude/skills/) — custom skills and their prompts.
+- [`.github/copilot-instructions.md`](.github/copilot-instructions.md) —
+  Copilot review rules.
+- [`CLAUDE.md`](CLAUDE.md) — contribution rules read by Claude Code on every
+  invocation.
+
+A reader can reconstruct **what changed, when, why, and under which rules**.
+What cannot be reconstructed: which exact prompt produced which exact diff —
+see below.
+
+---
+
+## What this document does not cover
+
+- Line-level or function-level AI vs. human authorship. Not tracked.
+- Exact model per commit. Not tracked.
+- Prompt-to-diff mapping. Not preserved.
+- "Human-reviewed" means the maintainer read the change and judged it fit to
+  merge; understands it well enough to defend, extend, and debug it. It does
+  not mean formal verification or line-by-line inspection.
+- AI tools can produce plausible-looking but wrong code. The verification
+  layers above reduce that risk; they do not eliminate it. Anything that
+  ships is the maintainer's responsibility.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@
 
 **Tests**: `respx` for HTTP mocking, `pytest-asyncio` auto mode. Mocks over real API calls.
 
+**Commits**: Conventional-Commits with scope (`feat(providers): …`, `fix(core): …`, `chore(release): …`). Imperative, lowercase after the colon, single-line subject. Types and scopes documented in `CONTRIBUTING.md`. The PR title becomes the squash-merge commit on `main`, so the same rule applies to PR titles.
+
+**Versions**: when bumping the version, update **both** `pyproject.toml` and `CHANGELOG.md` in the same commit. The `version-linearity` CI job fails when they disagree.
+
 ## Architecture (read these first)
 - `core/engine.py` — workflow executor, layer-based parallel DAG traversal
 - `core/dag.py` — dependency graph, topological sort, cycle detection

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,13 +49,33 @@ uv run pytest
 
 ## Commit messages
 
-Short, lowercase, imperative mood. Prefix with category when relevant:
+Conventional-Commits style with scope:
 
 ```
-add retry jitter configuration
-fix router expression parsing for nested attributes
-refactor gateway fallback logic
+feat(providers): add streaming usage extraction for Anthropic
+fix(steps): respect router skip closure across parallel branches
+chore(release): bump version to 0.5.0
+ci(version): add version-linearity gate
+docs(observability): document OTel span schema migration
+refactor(gateway): extract candidate cache into LRU helper
+test(providers): add 429 contract suite parametrised across adapters
+perf(state): swap dict-snapshot for copy-on-write read view
+build(deps): pin httpx to 0.28.x for connection-pool compatibility
+style(core): apply ruff format
 ```
+
+- Imperative mood, lowercase after the colon. Single-line subject under
+  ~72 chars; body only when justification adds value.
+- Types: `feat`, `fix`, `chore`, `ci`, `test`, `docs`, `refactor`,
+  `perf`, `build`, `style`.
+- Common scopes: `core`, `cli`, `providers`, `observability`, `steps`,
+  `resilience`, `tools`, `webhooks`, `checkpointing`, `record-replay`,
+  `release`, `deps`, `version`, `meta`, `examples`, `infrastructure`.
+- PR-merge commits append `(#NN)` and may include `(#issue)` references —
+  e.g. `feat(providers): add structured output (#117) (#42)`.
+
+The PR title becomes the squash-merge commit on `main`, so the same
+convention applies to PR titles. The `pr` skill enforces this.
 
 ## Pull requests
 

--- a/scripts/check_version_linearity.py
+++ b/scripts/check_version_linearity.py
@@ -29,7 +29,13 @@ def check(root: Path) -> tuple[int, str]:
     if not changelog_path.exists():
         return 1, f"CHANGELOG.md not found at {changelog_path}"
 
-    declared = tomllib.loads(pyproject_path.read_text())["project"]["version"]
+    try:
+        declared = tomllib.loads(pyproject_path.read_text())["project"]["version"]
+    except tomllib.TOMLDecodeError as exc:
+        return 1, f"invalid pyproject.toml: {exc}"
+    except (KeyError, TypeError):
+        return 1, "pyproject.toml must define [project].version"
+
     latest = latest_changelog_version(changelog_path.read_text())
 
     if latest is None:

--- a/scripts/check_version_linearity.py
+++ b/scripts/check_version_linearity.py
@@ -1,0 +1,50 @@
+"""Fail CI if pyproject.toml and CHANGELOG.md disagree on the latest version.
+
+Invoked from `.github/workflows/ci.yml` job `version-linearity`. Also runnable
+locally as a pre-commit check. Mirrors the same gate used in agentanvil so
+release prep stays consistent across the two repos.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+VERSION_HEADER_RE = re.compile(r"^##\s*\[?(\d+\.\d+\.\d+[\w.]*)\]?", re.M)
+
+
+def latest_changelog_version(text: str) -> str | None:
+    match = VERSION_HEADER_RE.search(text)
+    return match.group(1) if match else None
+
+
+def check(root: Path) -> tuple[int, str]:
+    """Return (exit_code, message). 0 = ok, non-zero = fail."""
+    pyproject_path = root / "pyproject.toml"
+    changelog_path = root / "CHANGELOG.md"
+    if not pyproject_path.exists():
+        return 1, f"pyproject.toml not found at {pyproject_path}"
+    if not changelog_path.exists():
+        return 1, f"CHANGELOG.md not found at {changelog_path}"
+
+    declared = tomllib.loads(pyproject_path.read_text())["project"]["version"]
+    latest = latest_changelog_version(changelog_path.read_text())
+
+    if latest is None:
+        return 1, "CHANGELOG.md has no versioned entry"
+    if declared != latest:
+        return 1, f"version mismatch: pyproject.toml={declared} vs CHANGELOG.md={latest}"
+    return 0, f"version-linearity OK: {declared}"
+
+
+def main(root: Path | None = None) -> int:
+    code, message = check(root or Path.cwd())
+    stream = sys.stdout if code == 0 else sys.stderr
+    print(message, file=stream)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scripts/test_version_linearity.py
+++ b/tests/scripts/test_version_linearity.py
@@ -13,8 +13,8 @@ SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "check_vers
 def _load_script():
     """Import the script as a module (it is under scripts/, outside the package tree)."""
     spec = importlib.util.spec_from_file_location("check_version_linearity", SCRIPT)
-    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
     assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
@@ -77,6 +77,22 @@ def test_version_linearity_fails_when_changelog_missing(tmp_path: Path, script) 
     code, message = script.check(tmp_path)
     assert code == 1
     assert "CHANGELOG.md not found" in message
+
+
+def test_version_linearity_fails_on_malformed_pyproject(tmp_path: Path, script) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project\nversion = "1.0.0"\n')
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\n## [1.0.0] - 2026-04-28\n")
+    code, message = script.check(tmp_path)
+    assert code == 1
+    assert "invalid pyproject.toml" in message
+
+
+def test_version_linearity_fails_when_pyproject_lacks_version(tmp_path: Path, script) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "x"\n')
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\n## [1.0.0] - 2026-04-28\n")
+    code, message = script.check(tmp_path)
+    assert code == 1
+    assert "[project].version" in message
 
 
 def test_latest_changelog_version_picks_first_versioned_header(script) -> None:

--- a/tests/scripts/test_version_linearity.py
+++ b/tests/scripts/test_version_linearity.py
@@ -1,0 +1,109 @@
+"""Tests for `scripts/check_version_linearity.py`."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parent.parent.parent / "scripts" / "check_version_linearity.py"
+
+
+def _load_script():
+    """Import the script as a module (it is under scripts/, outside the package tree)."""
+    spec = importlib.util.spec_from_file_location("check_version_linearity", SCRIPT)
+    module = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    assert spec is not None and spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script():
+    return _load_script()
+
+
+def _write_repo(tmp_path: Path, *, py_version: str, changelog: str) -> None:
+    (tmp_path / "pyproject.toml").write_text(f'[project]\nversion = "{py_version}"\n')
+    (tmp_path / "CHANGELOG.md").write_text(changelog)
+
+
+def test_version_linearity_passes_on_clean_state(tmp_path: Path, script) -> None:
+    _write_repo(
+        tmp_path,
+        py_version="1.2.3",
+        changelog="# Changelog\n\n## [1.2.3] - 2026-04-26\n",
+    )
+    code, message = script.check(tmp_path)
+    assert code == 0
+    assert "1.2.3" in message
+
+
+def test_version_linearity_fails_on_mismatch(tmp_path: Path, script) -> None:
+    _write_repo(
+        tmp_path,
+        py_version="1.2.3",
+        changelog="# Changelog\n\n## [1.2.4] - 2026-04-26\n",
+    )
+    code, message = script.check(tmp_path)
+    assert code == 1
+    assert "mismatch" in message
+    assert "1.2.3" in message and "1.2.4" in message
+
+
+def test_version_linearity_fails_on_changelog_without_versioned_entry(
+    tmp_path: Path, script
+) -> None:
+    _write_repo(
+        tmp_path,
+        py_version="1.2.3",
+        changelog="# Changelog\n\n## [Unreleased]\n",
+    )
+    code, message = script.check(tmp_path)
+    assert code == 1
+    assert "no versioned entry" in message
+
+
+def test_version_linearity_fails_when_pyproject_missing(tmp_path: Path, script) -> None:
+    (tmp_path / "CHANGELOG.md").write_text("# Changelog\n\n## [1.0.0]\n")
+    code, message = script.check(tmp_path)
+    assert code == 1
+    assert "pyproject.toml not found" in message
+
+
+def test_version_linearity_fails_when_changelog_missing(tmp_path: Path, script) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nversion = "1.0.0"\n')
+    code, message = script.check(tmp_path)
+    assert code == 1
+    assert "CHANGELOG.md not found" in message
+
+
+def test_latest_changelog_version_picks_first_versioned_header(script) -> None:
+    text = """# Changelog
+
+## [Unreleased]
+
+## [2.0.0] - 2026-05-01
+
+## [1.0.0] - 2026-01-01
+"""
+    assert script.latest_changelog_version(text) == "2.0.0"
+
+
+def test_latest_changelog_version_handles_pre_release_suffix(script) -> None:
+    text = "## [0.2.0a0] - 2026-04-26\n"
+    assert script.latest_changelog_version(text) == "0.2.0a0"
+
+
+def test_latest_changelog_version_returns_none_for_unreleased_only(script) -> None:
+    text = "# Changelog\n\n## [Unreleased]\n"
+    assert script.latest_changelog_version(text) is None
+
+
+def test_check_against_real_repo_passes() -> None:
+    """The repo itself must always pass version-linearity (regression guard)."""
+    repo_root = Path(__file__).resolve().parent.parent.parent
+    module = _load_script()
+    code, message = module.check(repo_root)
+    assert code == 0, message

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 
 [[package]]
 name = "agentloom"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## What

Brings attribution, skills and CI conventions into line with agentanvil PR #1.

- Conventional Commits with scope documented in `CONTRIBUTING.md`, `CLAUDE.md`, `copilot-instructions.md` and the `pr` skill — agentloom-specific scopes added.
- `ATTRIBUTION.md` rewritten in agentanvil's format (Last updated header, maintainer accountability, Models used, How the work is split, Shared blind spots, What this document does not cover).
- New CI gate `version-linearity`: fails when `pyproject.toml` and `CHANGELOG.md` disagree (`scripts/check_version_linearity.py` + 9 tests + new ci.yml job).
- `labeler.yml` gains `dependencies` and `documentation`; `analyze` / `review` skills synced to agentanvil wording.

## Why

Single dev style across the two sibling repos. The version-linearity gate would already have caught the `uv.lock` drift this PR fixes (`0.3.0` → `0.4.0`).

## Testing

- [x] `uv run pytest` passes (852 + 9 new version-linearity tests)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run mypy src/` clean
- [x] `python scripts/check_version_linearity.py` — `version-linearity OK: 0.4.0`

## Notes

- Docs + CI tooling only, no runtime changes.