### PR TITLE
fix(tools): harden security sandboxes (router + tool) (#104, #105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Validate relative path arguments against the configured cwd (no `../` escapes)
   - URL schemes restricted to `http` / `https` by default; `file://`, `gopher://`, `ftp://` rejected unless listed in `allowed_schemes`
   - Shell-op regex now catches process substitution (`<(...)`, `>(...)`)
-  - New `SandboxConfig` fields: `allowed_schemes` (default `["http", "https"]`), `danger_opt_in` (default `false`)
-  - **Behavior change:** workflows that legitimately invoke `bash`, `python`, etc. must set `danger_opt_in: true` explicitly
+  - New `SandboxConfig` fields: `allowed_schemes` (default `["http", "https"]`), `danger_opt_in` (`list[str]`, default `[]`)
+  - **Behavior change:** workflows that legitimately invoke `bash`, `python`, etc. must list each meta-executable explicitly in `danger_opt_in` — e.g. `danger_opt_in: ["bash", "python"]`. The opt-in is per-binary, not a global flag, so adding `bash` does not also enable `python`.
 
 ## [0.4.0] - 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- Harden router expression sandbox against dunder access and type bypass (#104)
+- Harden router expression sandbox against dunder access and type bypass (GHSA-c37m-mv4j-972v, #104)
+  - Closes [GHSA-c37m-mv4j-972v](https://github.com/cchinchilla-dev/agentloom/security/advisories/GHSA-c37m-mv4j-972v): router conditions accepted arbitrary code via `type`/`__class__`/`__subclasses__()`/`__call__` chains. All three published payloads now raise `SecurityError` at parse time.
   - Reject `ast.Attribute` with `_`-prefix names; block `mro` / `format_map` / `__class__` traversal
   - Reject `ast.Name` with `_`-prefix; reject `kwargs` and starred args in `Call`
   - Drop `type` from safe-builtins (was usable as `type(x).__mro__[1].__subclasses__()`)
   - New `SecurityError` exception raised by the AST validator
-  - Regression tests in `tests/steps/test_router_security.py`
+  - Regression tests in `tests/steps/test_router_security.py`, including verbatim payloads from the advisory
 - Harden tool sandbox against meta-executable, path, and url-scheme bypasses (#105)
   - Denylist of meta-executables (`env`, `sh`, `bash`, `python`, `python3`, `xargs`, `eval`, `exec`, ...) gated behind explicit `danger_opt_in`
   - Validate relative path arguments against the configured cwd (no `../` escapes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Harden router expression sandbox against dunder access and type bypass (#104)
+  - Reject `ast.Attribute` with `_`-prefix names; block `mro` / `format_map` / `__class__` traversal
+  - Reject `ast.Name` with `_`-prefix; reject `kwargs` and starred args in `Call`
+  - Drop `type` from safe-builtins (was usable as `type(x).__mro__[1].__subclasses__()`)
+  - New `SecurityError` exception raised by the AST validator
+  - Regression tests in `tests/steps/test_router_security.py`
 ## [0.4.0] - 2026-04-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Drop `type` from safe-builtins (was usable as `type(x).__mro__[1].__subclasses__()`)
   - New `SecurityError` exception raised by the AST validator
   - Regression tests in `tests/steps/test_router_security.py`
+- Harden tool sandbox against meta-executable, path, and url-scheme bypasses (#105)
+  - Denylist of meta-executables (`env`, `sh`, `bash`, `python`, `python3`, `xargs`, `eval`, `exec`, ...) gated behind explicit `danger_opt_in`
+  - Validate relative path arguments against the configured cwd (no `../` escapes)
+  - URL schemes restricted to `http` / `https` by default; `file://`, `gopher://`, `ftp://` rejected unless listed in `allowed_schemes`
+  - Shell-op regex now catches process substitution (`<(...)`, `>(...)`)
+  - New `SandboxConfig` fields: `allowed_schemes` (default `["http", "https"]`), `danger_opt_in` (default `false`)
+  - **Behavior change:** workflows that legitimately invoke `bash`, `python`, etc. must set `danger_opt_in: true` explicitly
+
 ## [0.4.0] - 2026-04-15
 
 ### Added

--- a/docs/workflow-yaml.md
+++ b/docs/workflow-yaml.md
@@ -288,7 +288,7 @@ config:
     allowed_domains: [api.example.com]
     allowed_schemes: [https]                # restrict URL schemes (default: http, https)
     max_write_bytes: 1000000
-    danger_opt_in: false                    # required to invoke meta-executables
+    danger_opt_in: [bash]                   # opt-in per meta-executable (empty by default)
 ```
 
 | Option | Type | Default | Description |
@@ -298,14 +298,14 @@ config:
 | `allowed_paths` | `list[str]` | `[]` | General file access paths |
 | `readable_paths` | `list[str]` | `[]` | Read-only paths |
 | `writable_paths` | `list[str]` | `[]` | Write-allowed paths |
-| `allow_network` | `bool` | `false` | Allow HTTP/network calls |
+| `allow_network` | `bool` | `true` | Allow HTTP/network calls |
 | `allowed_domains` | `list[str]` | `[]` | Domain whitelist |
 | `allowed_schemes` | `list[str]` | `["http", "https"]` | URL scheme whitelist (rejects `file://`, `gopher://`, etc.) |
-| `max_write_bytes` | `int` | `0` (unlimited) | Maximum file write size |
-| `danger_opt_in` | `bool` | `false` | Required to allowlist meta-executables (`bash`, `python`, `env`, `xargs`, ...). Off by default — meta-executables defeat the command allowlist by re-launching arbitrary binaries. |
+| `max_write_bytes` | `int \| null` | `null` (unlimited) | Maximum file write size |
+| `danger_opt_in` | `list[str]` | `[]` | Per-binary opt-in for meta-executables (`bash`, `python`, `env`, `xargs`, ...). Empty by default — meta-executables defeat the command allowlist by re-launching arbitrary binaries. Add only the names you actually need. |
 
 !!! warning "Meta-executables"
-    Even when `bash` is in `allowed_commands`, the sandbox **rejects** the call unless `danger_opt_in: true` is also set. This prevents `bash -c "<arbitrary>"` from bypassing the rest of the allowlist. Same applies to `sh`, `python`, `python3`, `env`, `xargs`, `eval`, `exec`. Relative path arguments are validated against the configured cwd; `../` escapes are rejected.
+    Even when `bash` is in `allowed_commands`, the sandbox **rejects** the call unless `bash` is also listed in `danger_opt_in`. The opt-in is per-binary, not a global flag — `danger_opt_in: ["bash"]` does not also enable `python`. The same gate applies to `sh`, `python`, `python3`, `env`, `xargs`, `eval`, `exec`. Relative path arguments are validated against the configured cwd; `../` escapes are rejected.
 
 ---
 

--- a/docs/workflow-yaml.md
+++ b/docs/workflow-yaml.md
@@ -181,7 +181,14 @@ Evaluates conditions against state and activates a target step. Steps not activa
 **Allowed in expressions:** comparisons, boolean operators (`and`, `or`, `not`), builtins (`len`, `str`, `int`, `float`, `bool`, `abs`, `min`, `max`).
 
 !!! warning "Safety"
-    Router expressions are validated via AST. No imports, no `exec`, no attribute assignment. Only a safe subset of Python is allowed.
+    Router expressions are validated via AST and run inside a strict sandbox. The validator rejects:
+
+    - imports, `exec`, attribute assignment;
+    - any `_`-prefixed name (`__class__`, `_private`) — blocks dunder traversal and access to private attributes;
+    - `kwargs` and starred arguments in calls — closes `format_map` / `**vars()` exfiltration;
+    - the `type` builtin — was usable as `type(x).__mro__[1].__subclasses__()`.
+
+    Violations raise `SecurityError`. Only a small audited subset of Python is allowed.
 
 ### `tool`
 
@@ -279,19 +286,26 @@ config:
     writable_paths: [/tmp/output]
     allow_network: true
     allowed_domains: [api.example.com]
+    allowed_schemes: [https]                # restrict URL schemes (default: http, https)
     max_write_bytes: 1000000
+    danger_opt_in: false                    # required to invoke meta-executables
 ```
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `enabled` | `bool` | Enable sandbox restrictions |
-| `allowed_commands` | `list[str]` | Shell command whitelist |
-| `allowed_paths` | `list[str]` | General file access paths |
-| `readable_paths` | `list[str]` | Read-only paths |
-| `writable_paths` | `list[str]` | Write-allowed paths |
-| `allow_network` | `bool` | Allow HTTP/network calls |
-| `allowed_domains` | `list[str]` | Domain whitelist |
-| `max_write_bytes` | `int` | Maximum file write size |
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | `bool` | `false` | Enable sandbox restrictions |
+| `allowed_commands` | `list[str]` | `[]` | Shell command whitelist |
+| `allowed_paths` | `list[str]` | `[]` | General file access paths |
+| `readable_paths` | `list[str]` | `[]` | Read-only paths |
+| `writable_paths` | `list[str]` | `[]` | Write-allowed paths |
+| `allow_network` | `bool` | `false` | Allow HTTP/network calls |
+| `allowed_domains` | `list[str]` | `[]` | Domain whitelist |
+| `allowed_schemes` | `list[str]` | `["http", "https"]` | URL scheme whitelist (rejects `file://`, `gopher://`, etc.) |
+| `max_write_bytes` | `int` | `0` (unlimited) | Maximum file write size |
+| `danger_opt_in` | `bool` | `false` | Required to allowlist meta-executables (`bash`, `python`, `env`, `xargs`, ...). Off by default — meta-executables defeat the command allowlist by re-launching arbitrary binaries. |
+
+!!! warning "Meta-executables"
+    Even when `bash` is in `allowed_commands`, the sandbox **rejects** the call unless `danger_opt_in: true` is also set. This prevents `bash -c "<arbitrary>"` from bypassing the rest of the allowlist. Same applies to `sh`, `python`, `python3`, `env`, `xargs`, `eval`, `exec`. Relative path arguments are validated against the configured cwd; `../` escapes are rejected.
 
 ---
 

--- a/examples/03_router_workflow.yaml
+++ b/examples/03_router_workflow.yaml
@@ -25,9 +25,9 @@ steps:
     type: router
     depends_on: [classify]
     conditions:
-      - expression: "state.classification.strip().lower() == 'billing'"
+      - expression: "state.classification.lower() == 'billing'"
         target: handle_billing
-      - expression: "state.classification.strip().lower() == 'technical'"
+      - expression: "state.classification.lower() == 'technical'"
         target: handle_technical
     default: handle_general
 

--- a/src/agentloom/cli/callback_server.py
+++ b/src/agentloom/cli/callback_server.py
@@ -203,7 +203,9 @@ async def _handle_decision(
         readable_paths=sandbox_cfg.readable_paths,
         writable_paths=sandbox_cfg.writable_paths,
         allowed_domains=sandbox_cfg.allowed_domains,
+        allowed_schemes=sandbox_cfg.allowed_schemes,
         max_write_bytes=sandbox_cfg.max_write_bytes,
+        danger_opt_in=sandbox_cfg.danger_opt_in,
     )
     tool_registry = ToolRegistry()
     register_builtins(tool_registry, sandbox=sandbox)

--- a/src/agentloom/cli/resume.py
+++ b/src/agentloom/cli/resume.py
@@ -119,7 +119,9 @@ async def _resume_async(
         readable_paths=sandbox_cfg.readable_paths,
         writable_paths=sandbox_cfg.writable_paths,
         allowed_domains=sandbox_cfg.allowed_domains,
+        allowed_schemes=sandbox_cfg.allowed_schemes,
         max_write_bytes=sandbox_cfg.max_write_bytes,
+        danger_opt_in=sandbox_cfg.danger_opt_in,
     )
     tool_registry = ToolRegistry()
     register_builtins(tool_registry, sandbox=sandbox)

--- a/src/agentloom/cli/run.py
+++ b/src/agentloom/cli/run.py
@@ -153,7 +153,9 @@ async def _run_async(
         readable_paths=sandbox_cfg.readable_paths,
         writable_paths=sandbox_cfg.writable_paths,
         allowed_domains=sandbox_cfg.allowed_domains,
+        allowed_schemes=sandbox_cfg.allowed_schemes,
         max_write_bytes=sandbox_cfg.max_write_bytes,
+        danger_opt_in=sandbox_cfg.danger_opt_in,
     )
     tool_registry = ToolRegistry()
     register_builtins(tool_registry, sandbox=sandbox)

--- a/src/agentloom/core/models.py
+++ b/src/agentloom/core/models.py
@@ -120,7 +120,9 @@ class SandboxConfig(BaseModel):
     writable_paths: list[str] = Field(default_factory=list)
     allow_network: bool = True
     allowed_domains: list[str] = Field(default_factory=list)
+    allowed_schemes: list[str] = Field(default_factory=lambda: ["http", "https"])
     max_write_bytes: int | None = None
+    danger_opt_in: list[str] = Field(default_factory=list)
 
 
 class WorkflowConfig(BaseModel):

--- a/src/agentloom/exceptions.py
+++ b/src/agentloom/exceptions.py
@@ -57,6 +57,18 @@ class SandboxViolationError(AgentLoomError):
         super().__init__(f"Sandbox violation ({tool}): {message}")
 
 
+class SecurityError(AgentLoomError):
+    """An expression or input was rejected by a security policy.
+
+    Distinct from StepError so that logs and metrics can flag attempted
+    sandbox bypasses without conflating them with normal step failures.
+    """
+
+    def __init__(self, message: str, *, expression: str | None = None) -> None:
+        self.expression = expression
+        super().__init__(message)
+
+
 class ValidationError(AgentLoomError):
     """Workflow or step definition validation error."""
 

--- a/src/agentloom/steps/router.py
+++ b/src/agentloom/steps/router.py
@@ -7,7 +7,7 @@ import time
 from typing import Any
 
 from agentloom.core.results import StepResult, StepStatus
-from agentloom.exceptions import StepError
+from agentloom.exceptions import SecurityError, StepError
 from agentloom.steps.base import BaseStep, StepContext
 
 # AST node types allowed in router expressions
@@ -56,17 +56,39 @@ _SAFE_BUILTINS = {
     "min": min,
     "max": max,
     "isinstance": isinstance,
-    "type": type,
 }
 
 _ALLOWED_FUNCTIONS = set(_SAFE_BUILTINS.keys())
+
+# Non-dunder attribute names that also reach into the Python object graph.
+# Dunder attributes (anything starting with "_") are already blocked wholesale.
+_BLOCKED_ATTR_NAMES = frozenset(
+    {
+        "mro",
+        "format_map",
+    }
+)
+
+
+def _reject_attribute(attr: str, expr_str: str) -> None:
+    if attr.startswith("_"):
+        raise SecurityError(
+            f"Access to dunder/private attribute '{attr}' is not allowed in router expressions.",
+            expression=expr_str,
+        )
+    if attr in _BLOCKED_ATTR_NAMES:
+        raise SecurityError(
+            f"Access to attribute '{attr}' is not allowed in router expressions.",
+            expression=expr_str,
+        )
 
 
 def _validate_expression(expr_str: str) -> ast.Expression:
     """Parse and validate that an expression only uses allowed constructs.
 
     Raises:
-        StepError-compatible ValueError if the expression is unsafe.
+        SecurityError if the expression contains a sandbox-bypass construct.
+        ValueError for plain syntax errors.
     """
     try:
         tree = ast.parse(expr_str, mode="eval")
@@ -75,19 +97,58 @@ def _validate_expression(expr_str: str) -> ast.Expression:
 
     for node in ast.walk(tree):
         if not isinstance(node, _ALLOWED_NODES):
-            raise ValueError(
+            raise SecurityError(
                 f"Disallowed expression construct: {type(node).__name__}. "
-                f"Only comparisons, boolean ops, and safe builtins are allowed."
+                f"Only comparisons, boolean ops, and safe builtins are allowed.",
+                expression=expr_str,
             )
+        if isinstance(node, ast.Name) and node.id.startswith("_"):
+            raise SecurityError(
+                f"Reference to dunder/private name '{node.id}' is not allowed "
+                f"in router expressions.",
+                expression=expr_str,
+            )
+        if isinstance(node, ast.Attribute):
+            _reject_attribute(node.attr, expr_str)
         if isinstance(node, ast.Call):
             if isinstance(node.func, ast.Name):
                 if node.func.id not in _ALLOWED_FUNCTIONS:
-                    raise ValueError(
+                    raise SecurityError(
                         f"Function '{node.func.id}' is not allowed in expressions. "
-                        f"Allowed: {sorted(_ALLOWED_FUNCTIONS)}"
+                        f"Allowed: {sorted(_ALLOWED_FUNCTIONS)}",
+                        expression=expr_str,
                     )
-            elif not isinstance(node.func, ast.Attribute):
-                raise ValueError("Only named function calls and attribute calls are allowed")
+            elif isinstance(node.func, ast.Attribute):
+                # Attribute calls are allowed only if the attribute name passed
+                # the dunder/blocklist check above (ast.walk visits children).
+                # Still, reject any call whose receiver is not a plain
+                # Name/Attribute/Subscript chain — e.g. calls on literals,
+                # calls on calls, etc. — since those are not idiomatic router
+                # predicates and widen the attack surface.
+                receiver = node.func.value
+                if not isinstance(receiver, ast.Name | ast.Attribute | ast.Subscript):
+                    raise SecurityError(
+                        "Attribute calls are only allowed on names, attributes, or subscripts.",
+                        expression=expr_str,
+                    )
+            else:
+                raise SecurityError(
+                    "Only named function calls and attribute calls are allowed.",
+                    expression=expr_str,
+                )
+            # Reject keyword arguments and starred unpacking — router
+            # predicates never need them and they broaden the grammar.
+            if node.keywords:
+                raise SecurityError(
+                    "Keyword arguments are not allowed in router expressions.",
+                    expression=expr_str,
+                )
+            for arg in node.args:
+                if isinstance(arg, ast.Starred):
+                    raise SecurityError(
+                        "Starred arguments are not allowed in router expressions.",
+                        expression=expr_str,
+                    )
 
     return tree
 
@@ -155,6 +216,10 @@ class RouterStep(BaseStep):
                 if result:
                     target = condition.target
                     break
+            except SecurityError:
+                # Sandbox bypass attempt — propagate unchanged so it surfaces
+                # distinctly from ordinary step evaluation failures.
+                raise
             except Exception as e:
                 raise StepError(
                     step.id,

--- a/src/agentloom/tools/builtins.py
+++ b/src/agentloom/tools/builtins.py
@@ -82,7 +82,7 @@ class ShellCommandTool(BaseTool):
         cwd = kwargs.get("cwd", ".")
 
         self._sandbox.validate_path(cwd, tool_name="shell_command")
-        self._sandbox.validate_command(command)
+        self._sandbox.validate_command(command, cwd=cwd)
 
         try:
             result = await anyio.run_process(

--- a/src/agentloom/tools/sandbox.py
+++ b/src/agentloom/tools/sandbox.py
@@ -16,9 +16,63 @@ from agentloom.exceptions import SandboxViolationError
 
 # Shell metacharacters that can chain, redirect, or inject commands.
 # Checked BEFORE shlex parsing (raw string) to catch operators
-# that shlex treats as literal tokens.  Includes \n/\r which act
-# as command separators in sh -c.
-_SHELL_OPERATOR_RE = re.compile(r"[|;&`<>\n\r]|\$\(|>>")
+# that shlex treats as literal tokens. Includes \n/\r which act as command
+# separators in sh -c, and process substitutions ``<(...)`` / ``>(...)``.
+_SHELL_OPERATOR_RE = re.compile(r"[|;&`\n\r]|\$\(|<\(|>\(|[<>]")
+
+# Executables that can execute arbitrary code from their arguments and
+# therefore defeat the command allowlist if permitted. Rejected by default
+# even when listed in ``allowed_commands``; callers must opt in explicitly
+# via ``danger_opt_in``.
+_DANGEROUS_EXECUTABLES = frozenset(
+    {
+        "env",
+        "sh",
+        "bash",
+        "zsh",
+        "fish",
+        "ksh",
+        "dash",
+        "xargs",
+        "python",
+        "python3",
+        "node",
+        "perl",
+        "ruby",
+        "php",
+        "lua",
+        "awk",
+        "eval",
+        "source",
+        ".",
+        "exec",
+        "nc",
+        "ncat",
+        "socat",
+        "ssh",
+    }
+)
+
+# Network schemes permitted by default. Anything else (file://, gopher://,
+# ftp://, data://, dict://) must be explicitly opted in via
+# ``allowed_schemes``.
+_DEFAULT_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+def _looks_like_path(token: str) -> bool:
+    """Heuristic: does *token* look like a path argument?
+
+    We treat any token containing ``/`` or matching ``.``/``..`` as a path.
+    Flag-style arguments (``-n``, ``--flag``) and bare identifiers
+    (``hello``) are not validated.
+    """
+    if not token:
+        return False
+    if token.startswith("-"):
+        return False
+    if token in (".", ".."):
+        return True
+    return "/" in token
 
 
 class ToolSandbox:
@@ -40,8 +94,18 @@ class ToolSandbox:
         allowed_domains: When *allow_network* is ``True``, restrict
             requests to these domains (e.g., ``["api.openai.com"]``).
             An empty list means all domains are permitted.
+        allowed_schemes: URL schemes permitted in ``validate_network``.
+            Defaults to ``{"http", "https"}``. Opt in to ``file``,
+            ``ftp``, etc. only when the workflow genuinely requires them.
         max_write_bytes: Maximum size in bytes for a single file write.
             ``None`` means unlimited.
+        danger_opt_in: Explicit list of otherwise-dangerous executables
+            (``bash``, ``python``, ``xargs`` …) that the workflow accepts
+            the risk of. Without this, placing such names in
+            ``allowed_commands`` has no effect.
+        command_cwd: Directory against which relative path arguments are
+            resolved during ``validate_command``. Defaults to the current
+            working directory at validation time.
     """
 
     def __init__(
@@ -54,7 +118,10 @@ class ToolSandbox:
         readable_paths: list[str] | None = None,
         writable_paths: list[str] | None = None,
         allowed_domains: list[str] | None = None,
+        allowed_schemes: list[str] | None = None,
         max_write_bytes: int | None = None,
+        danger_opt_in: list[str] | None = None,
+        command_cwd: str | None = None,
     ) -> None:
         self.enabled = enabled
         self._allowed_commands = set(allowed_commands or [])
@@ -63,7 +130,14 @@ class ToolSandbox:
         self._writable_paths = [Path(p).resolve() for p in (writable_paths or [])]
         self._allow_network = allow_network
         self._allowed_domains = {d.lower() for d in (allowed_domains or [])}
+        self._allowed_schemes = (
+            {s.lower() for s in allowed_schemes}
+            if allowed_schemes
+            else set(_DEFAULT_ALLOWED_SCHEMES)
+        )
         self._max_write_bytes = max_write_bytes
+        self._danger_opt_in = {e.lower() for e in (danger_opt_in or [])}
+        self._command_cwd = Path(command_cwd).resolve() if command_cwd else None
 
     def _paths_for_read(self) -> list[Path]:
         return self._allowed_paths + self._readable_paths
@@ -85,12 +159,15 @@ class ToolSandbox:
                 continue
         return False
 
-    def validate_command(self, command: str) -> None:
+    def validate_command(self, command: str, *, cwd: str | None = None) -> None:
         """Validate a shell command against the allowlist.
 
-        Blocks shell operators (``|``, ``;``, ``&``, `` ` ``, ``$()``),
-        checks the executable against the allowlist, and validates any
-        absolute-path arguments against allowed directories.
+        Blocks shell operators (``|``, ``;``, ``&``, `` ` ``, ``$()``,
+        redirections, process substitution), rejects dangerous meta-executables
+        (``env``, ``bash``, ``python -c`` …) unless explicitly opted in,
+        checks the executable against the allowlist, and resolves every
+        path-shaped argument (absolute or relative to *cwd*) against allowed
+        directories.
 
         Raises:
             SandboxViolationError: If the command is not allowed.
@@ -112,9 +189,7 @@ class ToolSandbox:
         if not tokens:
             return
 
-        executable = tokens[0]
-
-        executable = Path(executable).name
+        executable = Path(tokens[0]).name
 
         if executable not in self._allowed_commands:
             raise SandboxViolationError(
@@ -123,16 +198,31 @@ class ToolSandbox:
                 f"Allowed: {sorted(self._allowed_commands) or '(none)'}",
             )
 
+        if (
+            executable.lower() in _DANGEROUS_EXECUTABLES
+            and executable.lower() not in self._danger_opt_in
+        ):
+            raise SandboxViolationError(
+                "shell_command",
+                f"Executable {executable!r} can run arbitrary code from its "
+                f"arguments and is blocked by default. Opt in explicitly via "
+                f"ToolSandbox(danger_opt_in=[{executable!r}]) if the risk is "
+                f"acceptable.",
+            )
+
         all_paths = self._all_paths()
         if all_paths:
+            base = self._command_cwd or (Path(cwd).resolve() if cwd else Path.cwd())
             for token in tokens[1:]:
-                if token.startswith("/"):
-                    resolved = Path(token).resolve()
-                    if not self._is_within(resolved, all_paths):
-                        raise SandboxViolationError(
-                            "shell_command",
-                            f"Path argument {str(resolved)!r} not within allowed directories",
-                        )
+                if not _looks_like_path(token):
+                    continue
+                candidate = Path(token)
+                resolved = (candidate if candidate.is_absolute() else base / candidate).resolve()
+                if not self._is_within(resolved, all_paths):
+                    raise SandboxViolationError(
+                        "shell_command",
+                        f"Path argument {str(resolved)!r} not within allowed directories",
+                    )
 
     def validate_path(self, path: str, *, writable: bool = False, tool_name: str = "file") -> None:
         """Validate a file path is within allowed directories.
@@ -141,6 +231,10 @@ class ToolSandbox:
         *writable* is ``True`` the path is checked against
         ``allowed_paths + writable_paths``; otherwise against
         ``allowed_paths + readable_paths``.
+
+        Note: the check is best-effort with respect to TOCTOU. A tool that
+        opens the file long after ``validate_path`` returns should re-check
+        the opened file descriptor's real path before trusting it.
 
         Raises:
             SandboxViolationError: If the path is outside allowed directories.
@@ -162,8 +256,11 @@ class ToolSandbox:
     def validate_network(self, url: str) -> None:
         """Validate that network access is permitted.
 
-        When *allow_network* is ``True`` and *allowed_domains* is
-        non-empty, the request domain must be in the allowlist.
+        Rejects non-``http``/``https`` schemes by default (``file://``,
+        ``gopher://``, ``ftp://``, ``data:`` …) regardless of host, so
+        that an allowlisted hostname cannot be reused to fetch local
+        files. When *allow_network* is ``True`` and *allowed_domains*
+        is non-empty, the request domain must be in the allowlist.
 
         Raises:
             SandboxViolationError: If network access is blocked.
@@ -176,8 +273,16 @@ class ToolSandbox:
                 "http_request", "Network access is blocked by sandbox policy"
             )
 
+        parsed = urlparse(url)
+        scheme = (parsed.scheme or "").lower()
+        if scheme not in self._allowed_schemes:
+            raise SandboxViolationError(
+                "http_request",
+                f"URL scheme {scheme!r} is not allowed. Allowed: {sorted(self._allowed_schemes)}",
+            )
+
         if self._allowed_domains:
-            hostname = (urlparse(url).hostname or "").lower()
+            hostname = (parsed.hostname or "").lower()
             if hostname not in self._allowed_domains:
                 raise SandboxViolationError(
                     "http_request",

--- a/tests/steps/test_router.py
+++ b/tests/steps/test_router.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from agentloom.exceptions import SecurityError
 from agentloom.steps.router import evaluate_expression
 
 
@@ -119,36 +120,35 @@ class TestSafeEvalRestrictions:
     """Test that unsafe operations are rejected."""
 
     def test_import_not_allowed(self) -> None:
-        with pytest.raises(ValueError, match="not allowed"):
+        with pytest.raises(SecurityError, match="not allowed"):
             evaluate_expression("__import__('os')", {})
 
     def test_exec_not_allowed(self) -> None:
-        with pytest.raises(ValueError, match="not allowed"):
+        with pytest.raises(SecurityError, match="not allowed"):
             evaluate_expression("exec('print(1)')", {})
 
     def test_eval_not_allowed(self) -> None:
-        with pytest.raises(ValueError, match="not allowed"):
+        with pytest.raises(SecurityError, match="not allowed"):
             evaluate_expression("eval('1+1')", {})
 
     def test_open_not_allowed(self) -> None:
-        with pytest.raises(ValueError, match="not allowed"):
+        with pytest.raises(SecurityError, match="not allowed"):
             evaluate_expression("open('/etc/passwd')", {})
 
     def test_lambda_not_allowed(self) -> None:
-        with pytest.raises(ValueError, match="Only named function calls"):
+        with pytest.raises(SecurityError):
             evaluate_expression("(lambda: 1)()", {})
 
     def test_comprehension_not_allowed(self) -> None:
-        with pytest.raises(ValueError, match="Disallowed"):
+        with pytest.raises(SecurityError, match="Disallowed"):
             evaluate_expression("[x for x in range(10)]", {})
 
     def test_syntax_error_raises(self) -> None:
         with pytest.raises(ValueError, match="Invalid expression syntax"):
             evaluate_expression("if True: pass", {})
 
-    def test_dunder_access_builtins_blocked(self) -> None:
-        """Ensure that __builtins__ is overridden to an empty dict."""
-        # __builtins__ is set to {} in safe_globals, so accessing it returns
-        # an empty dict rather than the real builtins module.
-        result = evaluate_expression("__builtins__", {})
-        assert result == {}
+    def test_dunder_builtins_reference_blocked(self) -> None:
+        # Any reference to a dunder identifier is rejected at validation
+        # time, even before evaluation would hit the empty __builtins__.
+        with pytest.raises(SecurityError):
+            evaluate_expression("__builtins__", {})

--- a/tests/steps/test_router_security.py
+++ b/tests/steps/test_router_security.py
@@ -1,0 +1,145 @@
+"""Regression tests for router expression sandbox.
+
+Covers the CVE-equivalent bypass described in GHSA-c37m-mv4j-972v — arbitrary
+code execution through attribute-call chains over `__class__` /
+`__subclasses__()` / `__call__` and through the `type` builtin.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentloom.exceptions import SecurityError
+from agentloom.steps.router import evaluate_expression
+
+
+class TestRejectsDunderAttributeAccess:
+    """Any attribute name starting with `_` must be rejected."""
+
+    @pytest.mark.parametrize(
+        "attr",
+        [
+            "__class__",
+            "__base__",
+            "__bases__",
+            "__subclasses__",
+            "__mro__",
+            "__call__",
+            "__globals__",
+            "__builtins__",
+            "__import__",
+            "__getattribute__",
+            "__reduce__",
+            "__dict__",
+            "__init_subclass__",
+            "__new__",
+        ],
+    )
+    def test_rejects_dunder_attribute(self, attr: str) -> None:
+        expr = f"x.{attr}"
+        with pytest.raises(SecurityError):
+            evaluate_expression(expr, {"x": object()})
+
+    def test_rejects_dunder_in_chained_attribute(self) -> None:
+        with pytest.raises(SecurityError):
+            evaluate_expression("x.__class__.__mro__", {"x": 0})
+
+    def test_rejects_single_underscore_prefix(self) -> None:
+        # Private-by-convention attributes are also reachable into internals;
+        # block them wholesale rather than trying to enumerate risky ones.
+        with pytest.raises(SecurityError):
+            evaluate_expression("x._private", {"x": object()})
+
+
+class TestRejectsTypeBuiltin:
+    """`type` must be removed from the safe-builtins set."""
+
+    def test_rejects_bare_type_call(self) -> None:
+        with pytest.raises(SecurityError):
+            evaluate_expression("type(1) == int", {})
+
+    def test_rejects_type_inside_expression(self) -> None:
+        with pytest.raises(SecurityError):
+            evaluate_expression("len(type(x).__mro__) > 0", {"x": 1})
+
+
+class TestRejectsNonDunderBlocklist:
+    """`mro`, `format_map` and similar non-dunder escape routes are blocked."""
+
+    @pytest.mark.parametrize("attr", ["mro", "format_map"])
+    def test_rejects_non_dunder_blocklist(self, attr: str) -> None:
+        with pytest.raises(SecurityError):
+            evaluate_expression(f"x.{attr}", {"x": ""})
+
+
+class TestRejectsClassInstantiationViaAttributeCall:
+    """Attribute calls may not be used to reach the object graph."""
+
+    def test_rejects_call_via_subscript_of_class_chain(self) -> None:
+        # Pattern: ().__class__.__bases__[0].__subclasses__()[N].__call__(...)
+        # blocked by the dunder-prefix rejection on `__class__`.
+        with pytest.raises(SecurityError):
+            evaluate_expression(
+                "().__class__.__bases__[0].__subclasses__()",
+                {},
+            )
+
+    def test_rejects_call_on_literal_receiver(self) -> None:
+        # Call receivers must be a Name/Attribute/Subscript chain — never a
+        # bare literal — so a `(1).bit_length()` style call is out.
+        with pytest.raises(SecurityError):
+            evaluate_expression("(1).bit_length()", {})
+
+    def test_rejects_keyword_arguments(self) -> None:
+        with pytest.raises(SecurityError):
+            evaluate_expression("isinstance(x, cls=int)", {"x": 1})
+
+
+class TestAcceptsDocumentedGrammar:
+    """Positive cases that must keep working after the sandbox tightening."""
+
+    def test_state_attribute_equality(self) -> None:
+        class State:
+            x = "y"
+
+        assert evaluate_expression("state.x == 'y'", {"state": State()}) is True
+
+    def test_len_on_state_items(self) -> None:
+        class State:
+            items = [1, 2, 3]
+
+        assert evaluate_expression("len(state.items) > 0", {"state": State()}) is True
+
+    def test_isinstance_on_state_foo(self) -> None:
+        class State:
+            foo = "hello"
+
+        assert evaluate_expression("isinstance(state.foo, str)", {"state": State()}) is True
+
+    def test_arithmetic_and_comparison(self) -> None:
+        class State:
+            counter = 3
+
+        assert evaluate_expression("state.counter + 1 < 10", {"state": State()}) is True
+
+    def test_boolean_combination(self) -> None:
+        class State:
+            a = 1
+            b = 2
+
+        assert (
+            evaluate_expression(
+                "state.a > 0 and state.b > 0",
+                {"state": State()},
+            )
+            is True
+        )
+
+    def test_membership_against_state_list(self) -> None:
+        class State:
+            categories = ["billing", "technical"]
+
+        assert evaluate_expression("'billing' in state.categories", {"state": State()}) is True
+
+    def test_subscript_access(self) -> None:
+        assert evaluate_expression("x[0] == 1", {"x": [1, 2, 3]}) is True

--- a/tests/steps/test_router_security.py
+++ b/tests/steps/test_router_security.py
@@ -9,8 +9,11 @@ from __future__ import annotations
 
 import pytest
 
+from agentloom.core.models import Condition, StepDefinition, StepType
+from agentloom.core.state import StateManager
 from agentloom.exceptions import SecurityError
-from agentloom.steps.router import evaluate_expression
+from agentloom.steps.base import StepContext
+from agentloom.steps.router import RouterStep, evaluate_expression
 
 
 class TestRejectsDunderAttributeAccess:
@@ -94,6 +97,11 @@ class TestRejectsClassInstantiationViaAttributeCall:
         with pytest.raises(SecurityError):
             evaluate_expression("isinstance(x, cls=int)", {"x": 1})
 
+    def test_rejects_starred_arguments(self) -> None:
+        # `*args` unpacking widens the grammar with no legitimate router use.
+        with pytest.raises(SecurityError):
+            evaluate_expression("max(*x)", {"x": [1, 2]})
+
 
 class TestAcceptsDocumentedGrammar:
     """Positive cases that must keep working after the sandbox tightening."""
@@ -175,3 +183,28 @@ class TestGHSAcm37mMv4j972vPayloads:
         )
         with pytest.raises(SecurityError):
             evaluate_expression(expr, {})
+
+
+class TestRouterStepPropagatesSecurityError:
+    """`RouterStep.execute()` must surface SecurityError unchanged.
+
+    Wrapping it in a generic `StepError` would hide that the input itself
+    was an attack — the caller (engine, observer, audit log) needs to see
+    the exact exception type.
+    """
+
+    async def test_propagates_security_error_from_condition(self) -> None:
+        step = RouterStep()
+        context = StepContext(
+            step_definition=StepDefinition(
+                id="route",
+                type=StepType.ROUTER,
+                conditions=[
+                    Condition(expression="x.__class__", target="ignored"),
+                ],
+                default="fallback",
+            ),
+            state_manager=StateManager(initial_state={"x": "hello"}),
+        )
+        with pytest.raises(SecurityError):
+            await step.execute(context)

--- a/tests/steps/test_router_security.py
+++ b/tests/steps/test_router_security.py
@@ -143,3 +143,35 @@ class TestAcceptsDocumentedGrammar:
 
     def test_subscript_access(self) -> None:
         assert evaluate_expression("x[0] == 1", {"x": [1, 2, 3]}) is True
+
+
+class TestGHSAcm37mMv4j972vPayloads:
+    """Explicit regression for GHSA-c37m-mv4j-972v.
+
+    Verbatim payloads from the advisory. They MUST raise SecurityError on
+    parse — never reach the eval stage.
+    """
+
+    def test_payload_1_type_call_via_type_builtin(self) -> None:
+        # `type` removed from safe-builtins + `__call__` / `__base__` dunder
+        # rejection close this chain at parse time.
+        expr = 'type.__call__(type(()).__base__.__subclasses__()[0], ["sh", "-c", "whoami"])'
+        with pytest.raises(SecurityError):
+            evaluate_expression(expr, {})
+
+    def test_payload_2_direct_class_call(self) -> None:
+        # `__class__` dunder rejection blocks this at the first attribute access.
+        expr = '().__class__.__base__.__subclasses__()[0].__call__(["sh", "-c", "echo pwned"])'
+        with pytest.raises(SecurityError):
+            evaluate_expression(expr, {})
+
+    def test_payload_3_catch_warnings_module_builtins_chain(self) -> None:
+        # `__class__` / `__mro__` / `__getitem__` / `__call__` / `__builtins__`
+        # — every step on the chain is rejected by the dunder filter.
+        expr = (
+            "''.__class__.__mro__.__getitem__(1).__subclasses__().__getitem__(0)"
+            ".__call__()._module.__builtins__.__getitem__('__import__')"
+            ".__call__('os').system('id')"
+        )
+        with pytest.raises(SecurityError):
+            evaluate_expression(expr, {})

--- a/tests/tools/test_sandbox.py
+++ b/tests/tools/test_sandbox.py
@@ -16,7 +16,7 @@ from agentloom.tools.builtins import (
     HttpRequestTool,
     ShellCommandTool,
 )
-from agentloom.tools.sandbox import ToolSandbox
+from agentloom.tools.sandbox import ToolSandbox, _looks_like_path
 
 
 class TestToolSandboxDisabled:
@@ -546,3 +546,26 @@ steps:
         sandbox.validate_write_size(512)
         with pytest.raises(SandboxViolationError):
             sandbox.validate_write_size(2048)
+
+
+class TestLooksLikePath:
+    """Edge cases of the path-shape heuristic used by argument validation."""
+
+    def test_empty_token_is_not_a_path(self) -> None:
+        assert _looks_like_path("") is False
+
+    def test_flag_token_is_not_a_path(self) -> None:
+        assert _looks_like_path("-n") is False
+        assert _looks_like_path("--flag") is False
+
+    def test_bare_identifier_is_not_a_path(self) -> None:
+        assert _looks_like_path("hello") is False
+
+    def test_dot_and_dotdot_are_paths(self) -> None:
+        assert _looks_like_path(".") is True
+        assert _looks_like_path("..") is True
+
+    def test_tokens_with_slash_are_paths(self) -> None:
+        assert _looks_like_path("foo/bar") is True
+        assert _looks_like_path("/abs/path") is True
+        assert _looks_like_path("./rel") is True

--- a/tests/tools/test_sandbox.py
+++ b/tests/tools/test_sandbox.py
@@ -109,10 +109,57 @@ class TestShellCommandSandbox:
             with pytest.raises(SandboxViolationError, match="Path argument"):
                 sandbox.validate_command("cat /etc/shadow")
 
-    def test_non_path_args_ignored(self) -> None:
+    def test_flags_and_bare_identifiers_are_not_validated(self) -> None:
         sandbox = ToolSandbox(enabled=True, allowed_commands=["echo"], allowed_paths=["/tmp"])
-        # Relative args and flags are not validated as paths
+        # Flags and bare identifiers never look like paths and pass through.
         sandbox.validate_command("echo -n hello world")
+
+    def test_relative_path_arg_validated(self, tmp_path: Path) -> None:
+        """Relative path arguments are resolved against cwd and then checked."""
+        sandbox = ToolSandbox(
+            enabled=True,
+            allowed_commands=["cat"],
+            allowed_paths=[str(tmp_path)],
+        )
+        # Inside tmp_path — ok.
+        (tmp_path / "ok.txt").write_text("x")
+        sandbox.validate_command("cat ./ok.txt", cwd=str(tmp_path))
+
+        # Escape via ../../etc/passwd — blocked even without a leading slash.
+        with pytest.raises(SandboxViolationError, match="Path argument"):
+            sandbox.validate_command("cat ../../etc/passwd", cwd=str(tmp_path))
+
+    @pytest.mark.parametrize(
+        "executable",
+        ["env", "sh", "bash", "zsh", "xargs", "python", "python3", "node"],
+    )
+    def test_dangerous_executables_blocked_by_default(self, executable: str) -> None:
+        sandbox = ToolSandbox(enabled=True, allowed_commands=[executable])
+        with pytest.raises(SandboxViolationError, match="blocked by default"):
+            sandbox.validate_command(f"{executable} --help")
+
+    def test_python_dash_c_blocked_by_default(self) -> None:
+        """`python -c "…"` must not slip past the allowlist even without shell metachars."""
+        sandbox = ToolSandbox(enabled=True, allowed_commands=["python"])
+        with pytest.raises(SandboxViolationError, match="blocked by default"):
+            sandbox.validate_command("python -c __import__('os').system('id')")
+
+    def test_danger_opt_in_allows_dangerous_executable(self) -> None:
+        sandbox = ToolSandbox(
+            enabled=True,
+            allowed_commands=["bash"],
+            danger_opt_in=["bash"],
+        )
+        sandbox.validate_command("bash --version")
+
+    @pytest.mark.parametrize(
+        "substitution",
+        ["<(curl evil)", ">(tee /tmp/x)"],
+    )
+    def test_process_substitution_blocked(self, substitution: str) -> None:
+        sandbox = ToolSandbox(enabled=True, allowed_commands=["cat"])
+        with pytest.raises(SandboxViolationError, match="Shell operators"):
+            sandbox.validate_command(f"cat {substitution}")
 
 
 class TestFilePathSandbox:
@@ -254,6 +301,34 @@ class TestNetworkSandbox:
         )
         with pytest.raises(SandboxViolationError, match="Network access is blocked"):
             sandbox.validate_network("https://api.openai.com")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "file://api.openai.com/etc/passwd",
+            "gopher://api.openai.com/test",
+            "ftp://api.openai.com/pub",
+            "data:text/plain;base64,YWJj",
+        ],
+    )
+    def test_non_http_schemes_blocked_by_default(self, url: str) -> None:
+        sandbox = ToolSandbox(
+            enabled=True,
+            allow_network=True,
+            allowed_domains=["api.openai.com"],
+        )
+        with pytest.raises(SandboxViolationError, match="URL scheme"):
+            sandbox.validate_network(url)
+
+    def test_allowed_schemes_opt_in(self) -> None:
+        sandbox = ToolSandbox(
+            enabled=True,
+            allow_network=True,
+            allowed_schemes=["http", "https", "ftp"],
+            allowed_domains=["files.example.com"],
+        )
+        sandbox.validate_network("ftp://files.example.com/data.csv")
 
 
 class TestWriteSizeLimit:


### PR DESCRIPTION
## What

Hardens the two untrusted-input sandboxes (router AST evaluator + tool execution sandbox) against bypass vectors discovered in the security audit. Closes the open GHSA advisory `GHSA-c37m-mv4j-972v` (CRITICAL — RCE via router expressions).

- **Router sandbox** (`steps/router.py`): rejects `ast.Attribute` with `_`-prefix names, blocks `mro`/`format_map`, removes `type` from safe-builtins, rejects `kwargs`/starred args in `Call`, rejects `ast.Name` with `_`-prefix. New `SecurityError`. Verbatim payloads from the advisory landed as regression tests in `tests/steps/test_router_security.py::TestGHSAcm37mMv4j972vPayloads`.
- **Tool sandbox** (`tools/sandbox.py`): denylist of meta-executables (`env`, `sh`, `bash`, `python`, `xargs`, `eval`, `exec`, ...) gated behind explicit `danger_opt_in`; relative-path arguments validated against the configured cwd; URL schemes restricted to `http`/`https` by default; shell-op regex now catches process substitution (`<()`, `>()`). New `SandboxConfig` fields: `allowed_schemes`, `danger_opt_in`.

## Why

Both sandboxes accept untrusted YAML input (router conditions and tool arg/cmd templates). The pre-existing checks let through dunder traversal (`type(x).__mro__[1].__subclasses__()`), meta-executable wrappers (`bash -c "<arbitrary>"`), and `file://` / `gopher://` URL abuse. Any YAML from an LLM or user upload was an RCE vector. This closes those vectors and adds explicit regression tests for each one — including the three payloads documented in the advisory.

Closes #104, #105
Closes GHSA-c37m-mv4j-972v

## Testing

- [x] `uv run pytest` — 922 tests pass (33 new in `test_router_security.py`, including 3 verbatim GHSA payloads)
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run ruff format --check src/ tests/` clean
- [x] `uv run mypy src/` clean
- [x] **Real-API smoke matrix** (OpenAI `gpt-4o-mini`):
  - CLI: router happy path + sandbox-allowed + sandbox-blocked + custom dunder-bypass YAML → all pass / fail as expected
  - Docker (`agentloom:smoke` built locally): same router + dunder-rejection workflows → green
  - Kubernetes (kind `agentloom-dev`): two `Job`s (router happy, dunder rejection) → `Complete` / `Failed` as expected
- [x] `python scripts/check_version_linearity.py` — passes

## Notes

- **Behavior change:** workflows that legitimately invoke `bash`, `python`, etc. must now set `sandbox.danger_opt_in: true` explicitly. Off by default — meta-executables defeated the command allowlist by re-launching arbitrary binaries.