### PR TITLE
add tool-calling example and replay support for tool-iteration loops (#116)

### DIFF
--- a/examples/35_tool_calling.yaml
+++ b/examples/35_tool_calling.yaml
@@ -1,0 +1,51 @@
+name: tool-calling-agent
+version: "1.0"
+description: |
+  Demonstrates native tool/function calling (#116). The model decides
+  at runtime to invoke ``http_request`` to fetch JSON from an API,
+  receives the result on the next turn, and emits a final answer.
+
+  Runs offline against the committed recording fixture. With
+  ``--provider openai --model gpt-4o-mini`` it makes real calls and
+  the model picks the tool autonomously.
+
+  Producing a fresh recording:
+    agentloom run examples/35_tool_calling.yaml --provider openai \\
+      --model gpt-4o-mini --record recordings/tool_calling.json
+
+config:
+  provider: mock
+  model: gpt-4o-mini
+  responses_file: recordings/tool_calling.json
+  latency_model: constant
+  latency_ms: 0
+  sandbox:
+    enabled: true
+    allow_network: true
+    allowed_domains: ["httpbin.org"]
+    allowed_schemes: ["https"]
+
+state:
+  question: "What HTTP method does the httpbin /get endpoint accept?"
+
+steps:
+  - id: ask
+    type: llm_call
+    prompt: "{state.question}"
+    tools:
+      - name: http_request
+        description: "Make an HTTP request to a given URL and return the response body."
+        parameters:
+          type: object
+          properties:
+            url:
+              type: string
+              description: "Full URL to GET."
+            method:
+              type: string
+              enum: ["GET", "POST"]
+              description: "HTTP method."
+          required: [url]
+    tool_choice: auto
+    max_tool_iterations: 3
+    output: answer

--- a/recordings/tool_calling.json
+++ b/recordings/tool_calling.json
@@ -1,0 +1,27 @@
+{
+  "ask": [
+    {
+      "content": "",
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "tool_calls": [
+        {
+          "id": "call_demo_1",
+          "name": "http_request",
+          "arguments": {"url": "https://httpbin.org/get", "method": "GET"}
+        }
+      ],
+      "usage": {"prompt_tokens": 35, "completion_tokens": 18, "total_tokens": 53},
+      "cost_usd": 0.000018,
+      "finish_reason": "tool_calls"
+    },
+    {
+      "content": "The /get endpoint of httpbin accepts the GET HTTP method, as confirmed by the successful response from https://httpbin.org/get.",
+      "provider": "openai",
+      "model": "gpt-4o-mini",
+      "usage": {"prompt_tokens": 320, "completion_tokens": 26, "total_tokens": 346},
+      "cost_usd": 0.000061,
+      "finish_reason": "stop"
+    }
+  ]
+}

--- a/src/agentloom/core/models.py
+++ b/src/agentloom/core/models.py
@@ -108,6 +108,24 @@ class ThinkingConfig(BaseModel):
     capture_reasoning: bool = True
 
 
+class ToolDefinition(BaseModel):
+    """LLM-callable tool declaration on an ``llm_call`` step (#116).
+
+    ``parameters`` is a JSON Schema object describing the function's
+    arguments. The provider adapters translate this declaration into the
+    wire format their API expects (OpenAI/Ollama use it as-is, Anthropic
+    nests it under ``input_schema``, Google nests it under
+    ``function_declarations``). Tool dispatch resolves ``name`` against
+    the workflow's ``tool_registry`` so a built-in or user-registered
+    tool runs the call.
+    """
+
+    name: str
+    description: str = ""
+    parameters: dict[str, Any] = Field(default_factory=dict)
+
+
+
 class StepDefinition(BaseModel):
     """Definition of a single workflow step."""
 
@@ -154,6 +172,15 @@ class StepDefinition(BaseModel):
 
     # Reasoning / extended thinking
     thinking: ThinkingConfig | None = None
+
+    # Tool calling (#116) — LLM picks tools at runtime
+    tools: list[ToolDefinition] = Field(default_factory=list)
+    # ``tool_choice``: "auto" | "required" | "none" | {"name": "..."}.
+    # Auto lets the model decide; required forces a tool call; none
+    # disables tools for this turn (useful for tool-augmented chats that
+    # want a final summary without further calls).
+    tool_choice: Any = "auto"
+    max_tool_iterations: int = 5
 
 
 class SandboxConfig(BaseModel):

--- a/src/agentloom/core/models.py
+++ b/src/agentloom/core/models.py
@@ -125,7 +125,6 @@ class ToolDefinition(BaseModel):
     parameters: dict[str, Any] = Field(default_factory=dict)
 
 
-
 class StepDefinition(BaseModel):
     """Definition of a single workflow step."""
 

--- a/src/agentloom/providers/anthropic.py
+++ b/src/agentloom/providers/anthropic.py
@@ -111,6 +111,13 @@ class AnthropicProvider(BaseProvider):
             else:
                 parts: list[dict[str, Any]] = []
                 for block in content:
+                    # Tool-calling messages (#116) build pure-dict wire-format
+                    # blocks (``tool_use``, ``tool_result``); pass those
+                    # through verbatim. Multimodal Pydantic blocks below need
+                    # translation to Anthropic's specific keys.
+                    if isinstance(block, dict):
+                        parts.append(block)
+                        continue
                     if isinstance(block, TextBlock):
                         parts.append({"type": "text", "text": block.text})
                     elif isinstance(block, ImageBlock):

--- a/src/agentloom/providers/anthropic.py
+++ b/src/agentloom/providers/anthropic.py
@@ -161,10 +161,22 @@ class AnthropicProvider(BaseProvider):
         max_tokens: int | None = None,
         **kwargs: Any,
     ) -> ProviderResponse:
+        agentloom_tools = kwargs.pop("agentloom_tools", None)
+        agentloom_tool_choice = kwargs.pop("agentloom_tool_choice", None)
         extras = validate_extra_kwargs(
             "anthropic", "complete", kwargs, _ANTHROPIC_EXTRA_PAYLOAD_KEYS
         )
         capture_reasoning = _translate_thinking_config(extras)
+        if agentloom_tools:
+            from agentloom.steps._tools import (
+                translate_tool_choice_for_anthropic,
+                translate_tools_for_anthropic,
+            )
+
+            extras["tools"] = translate_tools_for_anthropic(agentloom_tools)
+            mapped_choice = translate_tool_choice_for_anthropic(agentloom_tool_choice or "auto")
+            if mapped_choice is not None:
+                extras["tool_choice"] = mapped_choice
         system_prompt, filtered_messages = self._format_messages(messages)
 
         payload: dict[str, Any] = {
@@ -216,6 +228,10 @@ class AnthropicProvider(BaseProvider):
         )
         cost = calculate_cost(model, usage.prompt_tokens, usage.completion_tokens)
 
+        from agentloom.steps._tools import parse_tool_calls_from_anthropic
+
+        tool_calls = parse_tool_calls_from_anthropic(content_blocks)
+
         return ProviderResponse(
             content=content,
             model=data.get("model", model),
@@ -225,6 +241,7 @@ class AnthropicProvider(BaseProvider):
             reasoning_content=(
                 "".join(reasoning_parts) if reasoning_parts and capture_reasoning else None
             ),
+            tool_calls=tool_calls,
             raw_response=data,
             finish_reason=data.get("stop_reason"),
         )

--- a/src/agentloom/providers/base.py
+++ b/src/agentloom/providers/base.py
@@ -12,6 +12,21 @@ from agentloom.core.results import TokenUsage
 from agentloom.exceptions import ProviderError
 
 
+class ToolCall(BaseModel):
+    """A function-call decision returned by the model (#116).
+
+    ``id`` is provider-assigned and must round-trip back as
+    ``tool_call_id`` (OpenAI) or ``tool_use_id`` (Anthropic) on the
+    follow-up message that supplies the result. ``arguments`` is the
+    parsed JSON object — adapters do the JSON decode before constructing
+    this so the LLM step sees a usable dict rather than a string.
+    """
+
+    id: str
+    name: str
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
 class ProviderResponse(BaseModel):
     """Unified response from any LLM provider."""
 
@@ -30,6 +45,11 @@ class ProviderResponse(BaseModel):
     # Ollama returns ``message.thinking`` (or strips inline
     # ``<think>...</think>`` tags as a fallback).
     reasoning_content: str | None = None
+    # Tool calls (#116): empty list when the model didn't pick a tool.
+    # When non-empty, ``content`` may be empty (the model committed to a
+    # function call instead of text) — the LLM step dispatches each call
+    # via the tool registry and re-prompts with the results.
+    tool_calls: list[ToolCall] = Field(default_factory=list)
 
 
 class StreamResponse:

--- a/src/agentloom/providers/google.py
+++ b/src/agentloom/providers/google.py
@@ -180,8 +180,20 @@ class GoogleProvider(BaseProvider):
         max_tokens: int | None = None,
         **kwargs: Any,
     ) -> ProviderResponse:
+        agentloom_tools = kwargs.pop("agentloom_tools", None)
+        agentloom_tool_choice = kwargs.pop("agentloom_tool_choice", None)
         extras = validate_extra_kwargs("google", "complete", kwargs, _GOOGLE_EXTRA_PAYLOAD_KEYS)
         thinking_payload = _build_thinking_config_payload(extras.pop("thinking_config", None))
+        if agentloom_tools:
+            from agentloom.steps._tools import translate_tools_for_google
+
+            extras["tools"] = translate_tools_for_google(agentloom_tools)
+            mode = {
+                "auto": "AUTO",
+                "required": "ANY",
+                "none": "NONE",
+            }.get(agentloom_tool_choice or "auto", "AUTO")
+            extras["tool_config"] = {"functionCallingConfig": {"mode": mode}}
         system_instruction, contents = self._format_messages(messages)
 
         payload: dict[str, Any] = {"contents": contents}
@@ -217,9 +229,10 @@ class GoogleProvider(BaseProvider):
         candidates = data.get("candidates", [])
         content = ""
         reasoning_content: str | None = None
+        content_parts: list[dict[str, Any]] = []
         if candidates:
-            parts = candidates[0].get("content", {}).get("parts", [])
-            content, reasoning_trace = _parse_gemini_content_parts(parts)
+            content_parts = candidates[0].get("content", {}).get("parts", []) or []
+            content, reasoning_trace = _parse_gemini_content_parts(content_parts)
             if reasoning_trace:
                 reasoning_content = reasoning_trace
 
@@ -248,6 +261,11 @@ class GoogleProvider(BaseProvider):
         if candidates:
             finish_reason = candidates[0].get("finishReason")
 
+        from agentloom.steps._tools import parse_tool_calls_from_google
+
+        tool_calls = parse_tool_calls_from_google(content_parts)
+
+
         return ProviderResponse(
             content=content,
             model=model,
@@ -257,6 +275,7 @@ class GoogleProvider(BaseProvider):
             reasoning_content=reasoning_content,
             raw_response=data,
             finish_reason=finish_reason,
+            tool_calls=tool_calls,
         )
 
     async def stream(

--- a/src/agentloom/providers/google.py
+++ b/src/agentloom/providers/google.py
@@ -265,7 +265,6 @@ class GoogleProvider(BaseProvider):
 
         tool_calls = parse_tool_calls_from_google(content_parts)
 
-
         return ProviderResponse(
             content=content,
             model=model,

--- a/src/agentloom/providers/mock.py
+++ b/src/agentloom/providers/mock.py
@@ -109,7 +109,12 @@ class MockProvider(BaseProvider):
         self._observer = observer
         self._workflow_name = workflow_name
         self.calls: list[dict[str, Any]] = []
-        self._responses: dict[str, dict[str, Any]] = {}
+        # Each value is either a single response dict OR a list of turns
+        # to play in order (for tool-calling loops where one step issues
+        # multiple complete() calls). The cursor below tracks which turn
+        # the next call should emit per step_id.
+        self._responses: dict[str, Any] = {}
+        self._turn_cursor: dict[str, int] = {}
         if self.responses_file and self.responses_file.exists():
             raw = json.loads(self.responses_file.read_text())
             if not isinstance(raw, dict):
@@ -126,7 +131,18 @@ class MockProvider(BaseProvider):
         extra: dict[str, Any] | None = None,
     ) -> dict[str, Any] | None:
         if step_id and step_id in self._responses:
-            return self._responses[step_id]
+            entry = self._responses[step_id]
+            # List form: pop the next turn (clamp at last so excess
+            # iterations replay the final response — saner than
+            # raising mid-loop).
+            if isinstance(entry, list):
+                if not entry:
+                    return None
+                idx = self._turn_cursor.get(step_id, 0)
+                turn = entry[min(idx, len(entry) - 1)]
+                self._turn_cursor[step_id] = idx + 1
+                return turn if isinstance(turn, dict) else None
+            return entry if isinstance(entry, dict) else None
         key = prompt_hash(messages, model, temperature, max_tokens, extra)
         return self._responses.get(key)
 
@@ -185,10 +201,28 @@ class MockProvider(BaseProvider):
             )
 
         usage_data = entry.get("usage", {}) or {}
+        # Tool calls (#116): hydrate ``tool_calls`` from the recording so
+        # replay drives the LLM step's tool-iteration loop. Each turn in
+        # a list-shaped recording can carry its own ``tool_calls`` block.
+        tool_calls: list[Any] = []
+        recorded_tool_calls = entry.get("tool_calls") or []
+        if recorded_tool_calls:
+            from agentloom.providers.base import ToolCall
+
+            for tc in recorded_tool_calls:
+                tool_calls.append(
+                    ToolCall(
+                        id=str(tc.get("id", "")),
+                        name=str(tc.get("name", "")),
+                        arguments=tc.get("arguments", {}) or {},
+                    )
+                )
+
+
         return ProviderResponse(
             content=str(entry.get("content", "")),
             model=str(entry.get("model", model)),
-            provider=self.name,
+            provider=str(entry.get("provider", self.name)),
             usage=TokenUsage(
                 prompt_tokens=int(usage_data.get("prompt_tokens", 0)),
                 completion_tokens=int(usage_data.get("completion_tokens", 0)),
@@ -196,6 +230,7 @@ class MockProvider(BaseProvider):
             ),
             cost_usd=float(entry.get("cost_usd", 0.0)),
             finish_reason=entry.get("finish_reason", "stop"),
+            tool_calls=tool_calls,
         )
 
     def supports_model(self, model: str) -> bool:

--- a/src/agentloom/providers/mock.py
+++ b/src/agentloom/providers/mock.py
@@ -218,7 +218,6 @@ class MockProvider(BaseProvider):
                     )
                 )
 
-
         return ProviderResponse(
             content=str(entry.get("content", "")),
             model=str(entry.get("model", model)),

--- a/src/agentloom/providers/ollama.py
+++ b/src/agentloom/providers/ollama.py
@@ -225,7 +225,6 @@ class OllamaProvider(BaseProvider):
 
         tool_calls = parse_tool_calls_from_openai(data.get("message", {}) or {})
 
-
         return ProviderResponse(
             content=content,
             model=data.get("model", model),

--- a/src/agentloom/providers/ollama.py
+++ b/src/agentloom/providers/ollama.py
@@ -154,8 +154,23 @@ class OllamaProvider(BaseProvider):
         max_tokens: int | None = None,
         **kwargs: Any,
     ) -> ProviderResponse:
+        agentloom_tools = kwargs.pop("agentloom_tools", None)
+        agentloom_tool_choice = kwargs.pop("agentloom_tool_choice", None)
         extras = validate_extra_kwargs("ollama", "complete", kwargs, _OLLAMA_EXTRA_PAYLOAD_KEYS)
         think_param, capture_reasoning = _pop_thinking_config(extras)
+        if agentloom_tools:
+            from agentloom.steps._tools import translate_tools_for_ollama
+
+            extras["tools"] = translate_tools_for_ollama(agentloom_tools)
+            # Ollama doesn't expose tool_choice; only model-side support
+            # decides whether the call is honored. Surface the silent drop
+            # via debug log so users debugging "why doesn't my tool fire"
+            # have a hint.
+            if agentloom_tool_choice not in (None, "auto"):
+                logger.debug(
+                    "Ollama ignores tool_choice=%r; only model-side support matters.",
+                    agentloom_tool_choice,
+                )
         payload: dict[str, Any] = {
             "model": model,
             "messages": self._format_messages(messages),
@@ -206,6 +221,11 @@ class OllamaProvider(BaseProvider):
             total_tokens=prompt_tokens + completion_tokens,
         )
 
+        from agentloom.steps._tools import parse_tool_calls_from_openai
+
+        tool_calls = parse_tool_calls_from_openai(data.get("message", {}) or {})
+
+
         return ProviderResponse(
             content=content,
             model=data.get("model", model),
@@ -215,6 +235,7 @@ class OllamaProvider(BaseProvider):
             reasoning_content=reasoning_content,
             raw_response=data,
             finish_reason=data.get("done_reason"),
+            tool_calls=tool_calls,
         )
 
     async def stream(

--- a/src/agentloom/providers/openai.py
+++ b/src/agentloom/providers/openai.py
@@ -187,7 +187,6 @@ class OpenAIProvider(BaseProvider):
 
         tool_calls = parse_tool_calls_from_openai(message)
 
-
         return ProviderResponse(
             content=content,
             model=data.get("model", model),

--- a/src/agentloom/providers/openai.py
+++ b/src/agentloom/providers/openai.py
@@ -126,11 +126,25 @@ class OpenAIProvider(BaseProvider):
         max_tokens: int | None = None,
         **kwargs: Any,
     ) -> ProviderResponse:
+        # Tool definitions arrive as ``ToolDefinition`` Pydantic instances —
+        # translate to OpenAI's wire format before forwarding so callers
+        # don't have to know provider-specific shapes.
+        agentloom_tools = kwargs.pop("agentloom_tools", None)
+        agentloom_tool_choice = kwargs.pop("agentloom_tool_choice", None)
         extras = validate_extra_kwargs("openai", "complete", kwargs, _OPENAI_EXTRA_PAYLOAD_KEYS)
         # ``thinking_config`` is accepted at the step layer for YAML
         # uniformity but has no chat-completions equivalent — drop it
         # before splatting extras into the request body.
         extras.pop("thinking_config", None)
+        if agentloom_tools:
+            from agentloom.steps._tools import (
+                translate_tool_choice_for_openai,
+                translate_tools_for_openai,
+            )
+
+            extras["tools"] = translate_tools_for_openai(agentloom_tools)
+            if agentloom_tool_choice is not None and agentloom_tool_choice != "none":
+                extras["tool_choice"] = translate_tool_choice_for_openai(agentloom_tool_choice)
         payload: dict[str, Any] = {
             "model": model,
             "messages": self._format_messages(messages),
@@ -149,7 +163,8 @@ class OpenAIProvider(BaseProvider):
         raise_for_status("openai", response)
 
         data = response.json()
-        content = data["choices"][0]["message"]["content"]
+        message = data["choices"][0]["message"]
+        content = message.get("content") or ""
         usage_data = data.get("usage", {})
         # o-series returns reasoning tokens under completion_tokens_details;
         # ordinary gpt-* responses omit the field and resolve to 0.
@@ -168,6 +183,11 @@ class OpenAIProvider(BaseProvider):
             reasoning_tokens=usage.reasoning_tokens,
         )
 
+        from agentloom.steps._tools import parse_tool_calls_from_openai
+
+        tool_calls = parse_tool_calls_from_openai(message)
+
+
         return ProviderResponse(
             content=content,
             model=data.get("model", model),
@@ -176,6 +196,7 @@ class OpenAIProvider(BaseProvider):
             cost_usd=cost,
             raw_response=data,
             finish_reason=data["choices"][0].get("finish_reason"),
+            tool_calls=tool_calls,
         )
 
     async def stream(

--- a/src/agentloom/steps/_tools.py
+++ b/src/agentloom/steps/_tools.py
@@ -110,16 +110,34 @@ def translate_tool_choice_for_anthropic(choice: Any) -> Any:
 
 
 def parse_tool_calls_from_openai(message: dict[str, Any]) -> list[ToolCall]:
-    """OpenAI returns ``message.tool_calls = [{id, type, function: {name, arguments}}]``."""
+    """Parse ``message.tool_calls`` from OpenAI-shaped responses.
+
+    Handles both wire variants seen in the wild:
+
+    * **OpenAI canonical**: ``[{id, type:"function", function:{name, arguments:"<json>"}}]``
+      — ``arguments`` is a JSON-encoded string.
+    * **Ollama / OpenAI-compatible relays**: ``[{id, function:{name, arguments:{...}}}]``
+      — ``type`` may be omitted entirely, and ``arguments`` may already be a
+      decoded dict. Treat the absence of ``type`` as ``"function"`` (the
+      only call kind we currently dispatch); a non-function explicit
+      ``type`` (e.g. ``"code_interpreter"``) is skipped.
+    """
     raw_calls = message.get("tool_calls") or []
     calls: list[ToolCall] = []
     for entry in raw_calls:
-        if entry.get("type") != "function":
+        entry_type = entry.get("type", "function")
+        if entry_type != "function":
             continue
         fn = entry.get("function", {})
-        try:
-            args = json.loads(fn.get("arguments") or "{}")
-        except json.JSONDecodeError:
+        raw_args = fn.get("arguments")
+        if isinstance(raw_args, dict):
+            args: dict[str, Any] = raw_args
+        elif isinstance(raw_args, str):
+            try:
+                args = json.loads(raw_args or "{}")
+            except json.JSONDecodeError:
+                args = {}
+        else:
             args = {}
         calls.append(ToolCall(id=entry.get("id", ""), name=fn.get("name", ""), arguments=args))
     return calls

--- a/src/agentloom/steps/_tools.py
+++ b/src/agentloom/steps/_tools.py
@@ -1,0 +1,274 @@
+"""Helpers for the tool-calling flow (#116).
+
+Provider adapters call ``translate_tools_for_provider`` when building a
+request payload and ``parse_tool_calls_from_*`` after receiving a response.
+The LLM step uses ``dispatch_tool_calls`` to run them in parallel via
+the tool registry and ``build_tool_result_messages`` to feed the results
+back to the model on the next turn.
+
+Kept in one module so the wire-format translation lives in a single
+place per provider — adding Cohere or Bedrock later is one section
+here, not a hunt across four adapters.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+import anyio
+
+from agentloom.core.models import ToolDefinition
+from agentloom.providers.base import ToolCall
+
+logger = logging.getLogger("agentloom.steps")
+
+
+# ---------------------------------------------------------------------------
+# Outbound: ToolDefinition -> provider wire format
+# ---------------------------------------------------------------------------
+
+
+def translate_tools_for_openai(tools: list[ToolDefinition]) -> list[dict[str, Any]]:
+    """OpenAI shape: ``[{"type": "function", "function": {name, description, parameters}}]``."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": t.name,
+                "description": t.description,
+                "parameters": t.parameters or {"type": "object", "properties": {}},
+            },
+        }
+        for t in tools
+    ]
+
+
+def translate_tools_for_anthropic(tools: list[ToolDefinition]) -> list[dict[str, Any]]:
+    """Anthropic shape: ``[{name, description, input_schema}]``."""
+    return [
+        {
+            "name": t.name,
+            "description": t.description,
+            "input_schema": t.parameters or {"type": "object", "properties": {}},
+        }
+        for t in tools
+    ]
+
+
+def translate_tools_for_google(tools: list[ToolDefinition]) -> list[dict[str, Any]]:
+    """Google shape: ``[{"function_declarations": [{name, description, parameters}, ...]}]``.
+
+    Google groups all functions under one ``Tool`` object; we put them all
+    in a single declaration list since AgentLoom doesn't yet expose tool
+    grouping (everything is a function).
+    """
+    return [
+        {
+            "function_declarations": [
+                {
+                    "name": t.name,
+                    "description": t.description,
+                    "parameters": t.parameters or {"type": "object", "properties": {}},
+                }
+                for t in tools
+            ]
+        }
+    ]
+
+
+def translate_tools_for_ollama(tools: list[ToolDefinition]) -> list[dict[str, Any]]:
+    """Ollama uses the OpenAI shape on supported models."""
+    return translate_tools_for_openai(tools)
+
+
+def translate_tool_choice_for_openai(choice: Any) -> Any:
+    """OpenAI ``tool_choice`` accepts ``"auto"`` / ``"required"`` / ``"none"``
+    or ``{"type": "function", "function": {"name": "..."}}``."""
+    if isinstance(choice, dict) and "name" in choice:
+        return {"type": "function", "function": {"name": choice["name"]}}
+    return choice
+
+
+def translate_tool_choice_for_anthropic(choice: Any) -> Any:
+    """Anthropic uses ``{"type": "auto"}`` / ``"any"`` / ``"tool"``."""
+    if choice == "auto":
+        return {"type": "auto"}
+    if choice == "required":
+        return {"type": "any"}
+    if choice == "none":
+        return None  # omit the field entirely
+    if isinstance(choice, dict) and "name" in choice:
+        return {"type": "tool", "name": choice["name"]}
+    return {"type": "auto"}
+
+
+# ---------------------------------------------------------------------------
+# Inbound: provider response -> ToolCall list
+# ---------------------------------------------------------------------------
+
+
+def parse_tool_calls_from_openai(message: dict[str, Any]) -> list[ToolCall]:
+    """OpenAI returns ``message.tool_calls = [{id, type, function: {name, arguments}}]``."""
+    raw_calls = message.get("tool_calls") or []
+    calls: list[ToolCall] = []
+    for entry in raw_calls:
+        if entry.get("type") != "function":
+            continue
+        fn = entry.get("function", {})
+        try:
+            args = json.loads(fn.get("arguments") or "{}")
+        except json.JSONDecodeError:
+            args = {}
+        calls.append(ToolCall(id=entry.get("id", ""), name=fn.get("name", ""), arguments=args))
+    return calls
+
+
+def parse_tool_calls_from_anthropic(content_blocks: list[dict[str, Any]]) -> list[ToolCall]:
+    """Anthropic returns ``content`` blocks; ``type=tool_use`` carries calls."""
+    calls: list[ToolCall] = []
+    for block in content_blocks:
+        if block.get("type") != "tool_use":
+            continue
+        calls.append(
+            ToolCall(
+                id=block.get("id", ""),
+                name=block.get("name", ""),
+                arguments=block.get("input", {}) or {},
+            )
+        )
+    return calls
+
+
+def parse_tool_calls_from_google(content_parts: list[dict[str, Any]]) -> list[ToolCall]:
+    """Google returns parts with ``functionCall: {name, args}``. Ids aren't
+    provider-assigned so we synthesize them — the result message echoes
+    the same name (no id round-trip needed)."""
+    calls: list[ToolCall] = []
+    for idx, part in enumerate(content_parts):
+        fc = part.get("functionCall")
+        if not fc:
+            continue
+        calls.append(
+            ToolCall(
+                id=f"google-{idx}",
+                name=fc.get("name", ""),
+                arguments=fc.get("args", {}) or {},
+            )
+        )
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Tool dispatch (engine-side) and result-message synthesis
+# ---------------------------------------------------------------------------
+
+
+async def dispatch_tool_calls(
+    calls: list[ToolCall],
+    tool_registry: Any,
+) -> list[tuple[ToolCall, str, bool]]:
+    """Execute each call via the registry, in parallel.
+
+    Returns a list of ``(call, result_text, success)`` tuples in the
+    same order as ``calls``. Failed calls have ``success=False`` and a
+    stringified exception in ``result_text`` so the model can recover
+    on the next turn (the spec calls this "feed the failure back").
+    """
+    results: list[tuple[ToolCall, str, bool]] = [None] * len(calls)  # type: ignore[list-item]
+
+    async def _run(idx: int, call: ToolCall) -> None:
+        try:
+            tool = tool_registry.get(call.name)
+        except KeyError as e:
+            results[idx] = (call, f"tool '{call.name}' not registered: {e}", False)
+            return
+        try:
+            outcome = await tool.execute(**call.arguments)
+            text = outcome if isinstance(outcome, str) else json.dumps(outcome, default=str)
+            results[idx] = (call, text, True)
+        except Exception as e:  # noqa: BLE001 — reported back to the model
+            logger.warning("Tool '%s' failed: %s", call.name, e)
+            results[idx] = (call, f"tool execution failed: {e}", False)
+
+    async with anyio.create_task_group() as tg:
+        for idx, call in enumerate(calls):
+            tg.start_soon(_run, idx, call)
+
+    return results
+
+
+def build_assistant_message_with_tool_calls(
+    provider: str, content: str, calls: list[ToolCall]
+) -> dict[str, Any]:
+    """Replay the assistant's tool-call decision as a message on the next turn.
+
+    Required so the model sees its own previous decision — without this,
+    the conversation looks like the model spontaneously received tool
+    results without ever asking for them.
+    """
+    if provider == "anthropic":
+        blocks: list[dict[str, Any]] = []
+        if content:
+            blocks.append({"type": "text", "text": content})
+        for c in calls:
+            blocks.append({"type": "tool_use", "id": c.id, "name": c.name, "input": c.arguments})
+        return {"role": "assistant", "content": blocks}
+    if provider == "google":
+        return {
+            "role": "model",
+            "parts": [{"functionCall": {"name": c.name, "args": c.arguments}} for c in calls],
+        }
+    # OpenAI / Ollama. ``content`` must be a string (the AgentLoom-internal
+    # message formatter doesn't handle None even though OpenAI's API does);
+    # an empty string serializes as `""` which OpenAI accepts as "no text"
+    # alongside tool_calls.
+    return {
+        "role": "assistant",
+        "content": content or "",
+        "tool_calls": [
+            {
+                "id": c.id,
+                "type": "function",
+                "function": {"name": c.name, "arguments": json.dumps(c.arguments)},
+            }
+            for c in calls
+        ],
+    }
+
+
+def build_tool_result_messages(
+    provider: str, results: list[tuple[ToolCall, str, bool]]
+) -> list[dict[str, Any]]:
+    """Translate tool outcomes into the role/shape each provider expects."""
+    if provider == "anthropic":
+        # Single user turn with one tool_result block per call.
+        blocks: list[dict[str, Any]] = []
+        for call, text, success in results:
+            blocks.append(
+                {
+                    "type": "tool_result",
+                    "tool_use_id": call.id,
+                    "content": text,
+                    "is_error": not success,
+                }
+            )
+        return [{"role": "user", "content": blocks}]
+    if provider == "google":
+        return [
+            {
+                "role": "function",
+                "parts": [
+                    {
+                        "functionResponse": {
+                            "name": call.name,
+                            "response": {"result": text} if success else {"error": text},
+                        }
+                    }
+                    for call, text, success in results
+                ],
+            }
+        ]
+    # OpenAI / Ollama: one tool message per call, keyed by tool_call_id.
+    return [{"role": "tool", "tool_call_id": call.id, "content": text} for call, text, _ in results]

--- a/src/agentloom/steps/llm_call.py
+++ b/src/agentloom/steps/llm_call.py
@@ -57,6 +57,97 @@ class LLMCallStep(BaseStep):
     """Executes an LLM call with prompt template rendering from state."""
 
     @staticmethod
+    async def _run_tool_loop(
+        *,
+        context: StepContext,
+        step: StepDefinition,
+        messages: list[dict[str, Any]],
+        model: str,
+        provider_kwargs: dict[str, Any],
+    ) -> Any:
+        """Iterate `complete()` until the model stops requesting tools.
+
+        On each iteration: call the gateway, inspect ``response.tool_calls``,
+        dispatch them in parallel via the registry (when present), append
+        the assistant turn + tool result messages, and re-prompt. Cost and
+        token counts accumulate; the final response is returned.
+
+        ``max_tool_iterations`` bounds the loop to protect against models
+        that get stuck in a request/response oscillation. Without ``tools``
+        declared this collapses to a single call.
+        """
+        from agentloom.core.results import TokenUsage
+        from agentloom.providers.base import ProviderResponse
+        from agentloom.steps._tools import (
+            build_assistant_message_with_tool_calls,
+            build_tool_result_messages,
+            dispatch_tool_calls,
+        )
+
+        accumulated_prompt = 0
+        accumulated_completion = 0
+        accumulated_reasoning = 0
+        accumulated_cost = 0.0
+
+        max_iterations = max(step.max_tool_iterations, 1)
+        gateway = context.provider_gateway
+        assert gateway is not None  # caller validated already
+        for _ in range(max_iterations):
+            response = await gateway.complete(
+                messages=messages,
+                model=model,
+                temperature=step.temperature,
+                max_tokens=step.max_tokens,
+                step_id=step.id,
+                **provider_kwargs,
+            )
+            accumulated_prompt += response.usage.prompt_tokens
+            accumulated_completion += response.usage.completion_tokens
+            accumulated_reasoning += response.usage.reasoning_tokens
+            accumulated_cost += response.cost_usd
+
+            if not response.tool_calls or not step.tools:
+                # Replace the response usage with the accumulated totals so
+                # the caller sees the full conversation cost.
+                response.usage = TokenUsage(
+                    prompt_tokens=accumulated_prompt,
+                    completion_tokens=accumulated_completion,
+                    total_tokens=(
+                        accumulated_prompt + accumulated_completion + accumulated_reasoning
+                    ),
+                    reasoning_tokens=accumulated_reasoning,
+                )
+                response.cost_usd = accumulated_cost
+                return response
+
+            if context.tool_registry is None:
+                raise StepError(
+                    step.id,
+                    "Tool registry required for tools= declaration but not configured.",
+                )
+
+            results = await dispatch_tool_calls(response.tool_calls, context.tool_registry)
+            messages.append(
+                build_assistant_message_with_tool_calls(
+                    response.provider, response.content, response.tool_calls
+                )
+            )
+            messages.extend(build_tool_result_messages(response.provider, results))
+
+        # Loop exhausted; surface the last response with the cap noted as
+        # finish_reason so callers can detect it.
+        last_response: ProviderResponse = response  # noqa: F821 — set in loop
+        last_response.usage = TokenUsage(
+            prompt_tokens=accumulated_prompt,
+            completion_tokens=accumulated_completion,
+            total_tokens=(accumulated_prompt + accumulated_completion + accumulated_reasoning),
+            reasoning_tokens=accumulated_reasoning,
+        )
+        last_response.cost_usd = accumulated_cost
+        last_response.finish_reason = "max_tool_iterations"
+        return last_response
+
+    @staticmethod
     def _build_thinking_kwargs(step: StepDefinition) -> dict[str, Any]:
         """Forward ``StepDefinition.thinking`` to the gateway as a config object.
 
@@ -148,14 +239,21 @@ class LLMCallStep(BaseStep):
             )
 
         provider_kwargs = self._build_thinking_kwargs(step)
+        if step.tools:
+            provider_kwargs["agentloom_tools"] = step.tools
+            provider_kwargs["agentloom_tool_choice"] = step.tool_choice
+
+        # Tool-call loop: re-prompt with tool results until the model
+        # stops requesting tools or we exhaust ``max_tool_iterations``.
+        # Costs and tokens accumulate across iterations; only the final
+        # response's content is exposed to the caller.
         try:
-            response = await context.provider_gateway.complete(
+            response = await self._run_tool_loop(
+                context=context,
+                step=step,
                 messages=messages,
                 model=model,
-                temperature=step.temperature,
-                max_tokens=step.max_tokens,
-                step_id=step.id,
-                **provider_kwargs,
+                provider_kwargs=provider_kwargs,
             )
         except Exception as e:
             duration = (time.monotonic() - start) * 1000

--- a/tests/providers/test_tool_calling.py
+++ b/tests/providers/test_tool_calling.py
@@ -127,6 +127,30 @@ class TestToolParsing:
         assert len(calls) == 1
         assert calls[0].name == ""
 
+    def test_ollama_compat_response_with_dict_args_and_no_type(self) -> None:
+        # Real Ollama 0.x ``/api/chat`` returns tool_calls in OpenAI-compatible
+        # shape but (a) omits ``"type": "function"`` and (b) ships
+        # ``arguments`` as an already-decoded dict, not a JSON string. Without
+        # this regression, Ollama tool calling silently drops every call —
+        # the parser's strict ``type == "function"`` check skips entries
+        # missing the field, and ``json.loads(<dict>)`` would TypeError.
+        # Captured from a live ``llama3.1:8b`` response on 2026-05-09.
+        message = {
+            "tool_calls": [
+                {
+                    "id": "call_eh7yrv0u",
+                    "function": {
+                        "index": 0,
+                        "name": "add",
+                        "arguments": {"a": 17, "b": 25},  # already a dict
+                    },
+                    # NOTE: no "type" key
+                }
+            ]
+        }
+        calls = parse_tool_calls_from_openai(message)
+        assert calls == [ToolCall(id="call_eh7yrv0u", name="add", arguments={"a": 17, "b": 25})]
+
     def test_anthropic_parses_tool_use_blocks(self) -> None:
         blocks = [
             {"type": "text", "text": "I'll use a tool."},

--- a/tests/providers/test_tool_calling.py
+++ b/tests/providers/test_tool_calling.py
@@ -1,0 +1,530 @@
+"""Tests for native tool calling across providers (#116)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import httpx
+import respx
+
+from agentloom.core.engine import WorkflowEngine
+from agentloom.core.models import (
+    StepDefinition,
+    StepType,
+    ToolDefinition,
+    WorkflowConfig,
+    WorkflowDefinition,
+)
+from agentloom.core.results import StepStatus, WorkflowStatus
+from agentloom.providers.anthropic import AnthropicProvider
+from agentloom.providers.base import ToolCall
+from agentloom.providers.gateway import ProviderGateway
+from agentloom.providers.openai import OpenAIProvider
+from agentloom.steps._tools import (
+    build_assistant_message_with_tool_calls,
+    build_tool_result_messages,
+    dispatch_tool_calls,
+    parse_tool_calls_from_anthropic,
+    parse_tool_calls_from_google,
+    parse_tool_calls_from_openai,
+    translate_tools_for_anthropic,
+    translate_tools_for_google,
+    translate_tools_for_openai,
+)
+from agentloom.tools.base import BaseTool
+from agentloom.tools.registry import ToolRegistry
+
+
+class _AddTool(BaseTool):
+    name = "add"
+    description = "Add two integers."
+    parameters_schema = {
+        "type": "object",
+        "properties": {"a": {"type": "integer"}, "b": {"type": "integer"}},
+        "required": ["a", "b"],
+    }
+
+    async def execute(self, **kwargs: Any) -> Any:
+        return kwargs["a"] + kwargs["b"]
+
+
+class _LookupTool(BaseTool):
+    name = "lookup"
+    description = "Look up a value."
+    parameters_schema = {
+        "type": "object",
+        "properties": {"key": {"type": "string"}},
+        "required": ["key"],
+    }
+
+    async def execute(self, **kwargs: Any) -> Any:
+        return f"value-for-{kwargs['key']}"
+
+
+def _registry_with(*tools: BaseTool) -> ToolRegistry:
+    reg = ToolRegistry()
+    for t in tools:
+        reg.register(t)
+    return reg
+
+
+class TestToolTranslation:
+    def test_openai_shape(self) -> None:
+        out = translate_tools_for_openai(
+            [ToolDefinition(name="add", description="d", parameters={"type": "object"})]
+        )
+        assert out == [
+            {
+                "type": "function",
+                "function": {
+                    "name": "add",
+                    "description": "d",
+                    "parameters": {"type": "object"},
+                },
+            }
+        ]
+
+    def test_anthropic_shape(self) -> None:
+        out = translate_tools_for_anthropic(
+            [ToolDefinition(name="add", description="d", parameters={"type": "object"})]
+        )
+        assert out == [{"name": "add", "description": "d", "input_schema": {"type": "object"}}]
+
+    def test_google_shape_groups_under_function_declarations(self) -> None:
+        out = translate_tools_for_google(
+            [
+                ToolDefinition(name="add", description="d", parameters={"type": "object"}),
+                ToolDefinition(name="lookup", description="l", parameters={"type": "object"}),
+            ]
+        )
+        assert len(out) == 1
+        decls = out[0]["function_declarations"]
+        assert {d["name"] for d in decls} == {"add", "lookup"}
+
+
+class TestToolParsing:
+    def test_openai_parses_tool_calls(self) -> None:
+        message = {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "add", "arguments": '{"a": 2, "b": 3}'},
+                }
+            ],
+        }
+        calls = parse_tool_calls_from_openai(message)
+        assert calls == [ToolCall(id="call_1", name="add", arguments={"a": 2, "b": 3})]
+
+    def test_openai_skips_non_function_entries(self) -> None:
+        message = {"tool_calls": [{"id": "x", "type": "code_interpreter"}, {"type": "function"}]}
+        calls = parse_tool_calls_from_openai(message)
+        # Only the second entry is a function — its function dict is empty
+        # so name="" and args={}; we accept it (degenerate case).
+        assert len(calls) == 1
+        assert calls[0].name == ""
+
+    def test_anthropic_parses_tool_use_blocks(self) -> None:
+        blocks = [
+            {"type": "text", "text": "I'll use a tool."},
+            {"type": "tool_use", "id": "tu_1", "name": "lookup", "input": {"key": "x"}},
+        ]
+        calls = parse_tool_calls_from_anthropic(blocks)
+        assert calls == [ToolCall(id="tu_1", name="lookup", arguments={"key": "x"})]
+
+    def test_google_parses_function_call_parts(self) -> None:
+        parts = [
+            {"text": "I'll call a function."},
+            {"functionCall": {"name": "add", "args": {"a": 1, "b": 2}}},
+        ]
+        calls = parse_tool_calls_from_google(parts)
+        assert calls == [ToolCall(id="google-1", name="add", arguments={"a": 1, "b": 2})]
+
+
+class TestDispatchToolCalls:
+    async def test_dispatch_runs_in_parallel(self) -> None:
+        registry = _registry_with(_AddTool(), _LookupTool())
+        calls = [
+            ToolCall(id="c1", name="add", arguments={"a": 2, "b": 3}),
+            ToolCall(id="c2", name="lookup", arguments={"key": "alpha"}),
+        ]
+        results = await dispatch_tool_calls(calls, registry)
+        assert len(results) == 2
+        # Order preserved.
+        assert results[0][0].id == "c1"
+        assert results[0][1] == "5"
+        assert results[0][2] is True
+        assert results[1][1] == "value-for-alpha"
+
+    async def test_unknown_tool_yields_failure(self) -> None:
+        registry = _registry_with(_AddTool())
+        calls = [ToolCall(id="c1", name="missing", arguments={})]
+        results = await dispatch_tool_calls(calls, registry)
+        assert results[0][2] is False
+        assert "not registered" in results[0][1]
+
+    async def test_tool_exception_yields_failure(self) -> None:
+        class _Bad(BaseTool):
+            name = "bad"
+
+            async def execute(self, **kwargs: Any) -> Any:
+                raise RuntimeError("kaboom")
+
+        registry = _registry_with(_Bad())
+        calls = [ToolCall(id="c1", name="bad", arguments={})]
+        results = await dispatch_tool_calls(calls, registry)
+        assert results[0][2] is False
+        assert "kaboom" in results[0][1]
+
+
+class TestResultMessageBuilders:
+    def test_openai_role_tool_per_call(self) -> None:
+        c = ToolCall(id="c1", name="add", arguments={})
+        out = build_tool_result_messages("openai", [(c, "5", True)])
+        assert out == [{"role": "tool", "tool_call_id": "c1", "content": "5"}]
+
+    def test_anthropic_single_user_turn_with_tool_result_blocks(self) -> None:
+        c = ToolCall(id="tu_1", name="lookup", arguments={})
+        out = build_tool_result_messages("anthropic", [(c, "ok", True)])
+        assert len(out) == 1
+        assert out[0]["role"] == "user"
+        block = out[0]["content"][0]
+        assert block["type"] == "tool_result"
+        assert block["tool_use_id"] == "tu_1"
+        assert block["content"] == "ok"
+        assert block["is_error"] is False
+
+    def test_assistant_message_for_anthropic_includes_tool_use_blocks(self) -> None:
+        c = ToolCall(id="tu_1", name="lookup", arguments={"key": "x"})
+        msg = build_assistant_message_with_tool_calls("anthropic", "Thinking...", [c])
+        assert msg["role"] == "assistant"
+        assert msg["content"][0] == {"type": "text", "text": "Thinking..."}
+        assert msg["content"][1] == {
+            "type": "tool_use",
+            "id": "tu_1",
+            "name": "lookup",
+            "input": {"key": "x"},
+        }
+
+
+class TestOpenAIToolCallingWire:
+    @respx.mock
+    async def test_complete_returns_tool_calls_and_translates_tools(self) -> None:
+        route = respx.post("https://api.openai.com/v1/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [
+                                    {
+                                        "id": "c1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "add",
+                                            "arguments": '{"a": 2, "b": 3}',
+                                        },
+                                    }
+                                ],
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 5, "completion_tokens": 9},
+                },
+            )
+        )
+        provider = OpenAIProvider(api_key="k")
+        tools = [
+            ToolDefinition(
+                name="add",
+                description="add two ints",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "integer"},
+                        "b": {"type": "integer"},
+                    },
+                },
+            )
+        ]
+        r = await provider.complete(
+            messages=[{"role": "user", "content": "what is 2+3?"}],
+            model="gpt-4o-mini",
+            agentloom_tools=tools,
+        )
+        body = json.loads(route.calls[0].request.content)
+        assert body["tools"][0]["function"]["name"] == "add"
+        assert r.tool_calls == [ToolCall(id="c1", name="add", arguments={"a": 2, "b": 3})]
+        assert r.finish_reason == "tool_calls"
+        await provider.close()
+
+
+class TestAnthropicToolCallingWire:
+    @respx.mock
+    async def test_translates_tools_and_parses_tool_use_blocks(self) -> None:
+        route = respx.post("https://api.anthropic.com/v1/messages").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tu_1",
+                            "name": "lookup",
+                            "input": {"key": "alpha"},
+                        }
+                    ],
+                    "model": "claude-haiku-4-5-20251001",
+                    "stop_reason": "tool_use",
+                    "usage": {"input_tokens": 5, "output_tokens": 3},
+                },
+            )
+        )
+        provider = AnthropicProvider(api_key="k")
+        tools = [ToolDefinition(name="lookup", description="d", parameters={"type": "object"})]
+        r = await provider.complete(
+            messages=[{"role": "user", "content": "x"}],
+            model="claude-haiku-4-5-20251001",
+            agentloom_tools=tools,
+            agentloom_tool_choice="required",
+        )
+        body = json.loads(route.calls[0].request.content)
+        assert body["tools"][0]["name"] == "lookup"
+        assert body["tool_choice"] == {"type": "any"}
+        assert r.tool_calls == [ToolCall(id="tu_1", name="lookup", arguments={"key": "alpha"})]
+        await provider.close()
+
+
+class TestLLMStepToolLoop:
+    @respx.mock
+    async def test_step_dispatches_and_iterates(self) -> None:
+        # Iteration 1: model asks to call `add`.
+        # Iteration 2: model responds with the final answer.
+        respx.post("https://api.openai.com/v1/chat/completions").mock(
+            side_effect=[
+                httpx.Response(
+                    200,
+                    json={
+                        "model": "gpt-4o-mini",
+                        "choices": [
+                            {
+                                "message": {
+                                    "role": "assistant",
+                                    "content": None,
+                                    "tool_calls": [
+                                        {
+                                            "id": "c1",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "add",
+                                                "arguments": '{"a": 2, "b": 3}',
+                                            },
+                                        }
+                                    ],
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 5, "completion_tokens": 9},
+                    },
+                ),
+                httpx.Response(
+                    200,
+                    json={
+                        "model": "gpt-4o-mini",
+                        "choices": [
+                            {
+                                "message": {"role": "assistant", "content": "The answer is 5."},
+                                "finish_reason": "stop",
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 12, "completion_tokens": 6},
+                    },
+                ),
+            ]
+        )
+        workflow = WorkflowDefinition(
+            name="agent",
+            config=WorkflowConfig(provider="openai", model="gpt-4o-mini"),
+            state={},
+            steps=[
+                StepDefinition(
+                    id="ask",
+                    type=StepType.LLM_CALL,
+                    prompt="What is 2+3?",
+                    tools=[
+                        ToolDefinition(
+                            name="add",
+                            description="add two integers",
+                            parameters={
+                                "type": "object",
+                                "properties": {
+                                    "a": {"type": "integer"},
+                                    "b": {"type": "integer"},
+                                },
+                                "required": ["a", "b"],
+                            },
+                        )
+                    ],
+                    output="answer",
+                )
+            ],
+        )
+        gateway = ProviderGateway()
+        gateway.register(OpenAIProvider(api_key="k"))
+        engine = WorkflowEngine(
+            workflow=workflow,
+            provider_gateway=gateway,
+            tool_registry=_registry_with(_AddTool()),
+        )
+        result = await engine.run()
+        await gateway.close()
+
+        assert result.status == WorkflowStatus.SUCCESS
+        sr = result.step_results["ask"]
+        assert sr.status == StepStatus.SUCCESS
+        # Cost / tokens accumulated across both iterations.
+        assert sr.token_usage.prompt_tokens == 5 + 12
+        assert sr.token_usage.completion_tokens == 9 + 6
+        assert result.final_state["answer"] == "The answer is 5."
+
+    @respx.mock
+    async def test_step_respects_max_tool_iterations(self) -> None:
+        # Model never stops asking for the tool; loop must cap at 2.
+        respx.post("https://api.openai.com/v1/chat/completions").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "model": "gpt-4o-mini",
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": [
+                                    {
+                                        "id": "c1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "add",
+                                            "arguments": '{"a": 1, "b": 1}',
+                                        },
+                                    }
+                                ],
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 3, "completion_tokens": 2},
+                },
+            )
+        )
+        workflow = WorkflowDefinition(
+            name="agent-loop",
+            config=WorkflowConfig(provider="openai", model="gpt-4o-mini"),
+            state={},
+            steps=[
+                StepDefinition(
+                    id="ask",
+                    type=StepType.LLM_CALL,
+                    prompt="loop",
+                    tools=[
+                        ToolDefinition(
+                            name="add",
+                            description="d",
+                            parameters={"type": "object"},
+                        )
+                    ],
+                    max_tool_iterations=2,
+                    output="answer",
+                )
+            ],
+        )
+        gateway = ProviderGateway()
+        gateway.register(OpenAIProvider(api_key="k"))
+        engine = WorkflowEngine(
+            workflow=workflow,
+            provider_gateway=gateway,
+            tool_registry=_registry_with(_AddTool()),
+        )
+        result = await engine.run()
+        await gateway.close()
+
+        sr = result.step_results["ask"]
+        assert sr.status == StepStatus.SUCCESS
+        # Cap surfaced via finish_reason on the prompt metadata.
+        assert sr.prompt_metadata is not None
+        assert sr.prompt_metadata.finish_reason == "max_tool_iterations"
+
+    async def test_tool_dispatch_without_registry_raises(self) -> None:
+        # When a step declares tools but no registry is attached, the loop
+        # raises StepError surfaced as FAILED.
+        with respx.mock:
+            respx.post("https://api.openai.com/v1/chat/completions").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "model": "gpt-4o-mini",
+                        "choices": [
+                            {
+                                "message": {
+                                    "role": "assistant",
+                                    "content": None,
+                                    "tool_calls": [
+                                        {
+                                            "id": "c1",
+                                            "type": "function",
+                                            "function": {
+                                                "name": "add",
+                                                "arguments": "{}",
+                                            },
+                                        }
+                                    ],
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ],
+                        "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+                    },
+                )
+            )
+            workflow = WorkflowDefinition(
+                name="no-registry",
+                config=WorkflowConfig(provider="openai", model="gpt-4o-mini"),
+                state={},
+                steps=[
+                    StepDefinition(
+                        id="ask",
+                        type=StepType.LLM_CALL,
+                        prompt="hi",
+                        tools=[
+                            ToolDefinition(
+                                name="add", description="d", parameters={"type": "object"}
+                            )
+                        ],
+                        max_tool_iterations=1,
+                        retry={"max_retries": 0},
+                    )
+                ],
+            )
+            gateway = ProviderGateway()
+            gateway.register(OpenAIProvider(api_key="k"))
+            engine = WorkflowEngine(
+                workflow=workflow,
+                provider_gateway=gateway,
+                # tool_registry intentionally omitted
+            )
+            result = await engine.run()
+            await gateway.close()
+
+            sr = result.step_results["ask"]
+            assert sr.status == StepStatus.FAILED
+            assert "tool registry" in (sr.error or "").lower()


### PR DESCRIPTION
## What

Adds native tool / function calling across all four LLM providers. The model decides at runtime which tool to invoke; the engine dispatches the call via the existing `ToolRegistry`, feeds the result back as a follow-up message, and re-prompts until the model stops asking for tools (capped by `max_tool_iterations`, default 5).

- **Unified surface** — `StepDefinition.tools` (list of `ToolDefinition`), `tool_choice` (`"auto"` / `"required"` / `"none"` / `{"name": "..."}`), `max_tool_iterations`. New `ProviderResponse.tool_calls` field, new `ToolCall` model. `LLMCallStep._run_tool_loop` accumulates tokens + cost across iterations and surfaces `finish_reason="max_tool_iterations"` when the cap is hit so callers can detect runaway loops.
- **Per-provider wire translation** — each adapter maps the unified `tools` list to its native shape (OpenAI / Ollama: `tools=[{type:function, function:...}]`; Anthropic: `tools=[{name, input_schema}]`; Google: `function_declarations` grouped under one `tools` entry) and parses tool calls back from the response. Assistant + tool-result message synthesizers live in `agentloom.steps._tools` so the conversation building is consistent across providers.
- **Parallel dispatch** — multiple tool calls in one response are executed concurrently via an anyio task group; results preserve order. Tool failures (unknown name, exception) are reported back to the model as text so it can recover on the next turn rather than aborting the whole loop.
- **Sandbox / budget / retry honored** — dispatched calls go through `tool_registry.get(name).execute(args)`, which already enforces the sandbox (#105). The iteration loop respects budget (#108) and the existing per-step retry policy (#106).
- **MockProvider replay** — recordings can now carry a list of turns per step (one `complete()` call per loop iteration). Each turn's `tool_calls` block is hydrated as `ToolCall` objects so offline replay drives the loop end-to-end. New `examples/35_tool_calling.yaml` exercises a ReAct-style flow (`http_request` against httpbin.org) with the committed recording fixture.
- **Bug fix found via real-Ollama smoke** — `parse_tool_calls_from_openai` now handles two wire variants: OpenAI canonical (`type:"function"` + `arguments` as JSON string) and Ollama-compat (no `type` field, `arguments` as decoded dict). Without this, Ollama tool calling silently dropped every call. Regression test captured from a live `llama3.1:8b` response.

## Why

Closes the gap that the engine couldn't surface tool decisions to the LLM — `ToolStep` was a static DAG node, never a model-driven dispatch. Without this, ReAct loops, deep-research agents, function-calling assistants, and any benchmark that compares tool selection across models were inexpressible. Foundation for #119 (conversation history) and #120 (Agent primitive).

Closes #116

## Testing

- [x] `uv run pytest` — 1194 passed
- [x] `uv run ruff check src/ tests/` clean
- [x] `uv run mypy src/` clean
- [x] CLI smoke (mock replay): tool loop drives 2 iterations against the committed recording, final answer reaches state
- [x] Real-provider smoke (Ollama `llama3.1:8b`): full roundtrip, tool dispatched with correct args (17+25=42), 296 tokens across 2 iterations
- [x] Docker → Jaeger smoke (Ollama, real OTel collector): 4 spans visible — `workflow → step:solve → chat × 2 iterations`, all sharing `workflow.run_id`, canonical OTel `gen_ai.*` attrs per turn
- [x] Kubernetes smoke (kind cluster, host Ollama via `host.docker.internal`): tool dispatched (7+11=18), 346 tokens

## Notes

`ToolStep` (the static DAG node) keeps working unchanged for workflows that want explicit author-driven tool execution. The new `tools=` field on `llm_call` is the dynamic, model-driven path; nothing existing breaks.

Anthropic rolls thinking tokens into `output_tokens` (no separate field on the wire), so workflows combining `thinking` + `tools` on Claude show `reasoning_tokens=0` even when the model used extended thinking — documented limitation, cost is still correct.