### PR TITLE
ci(coverage): make codecov upload non-fatal on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: uv sync --group dev --all-extras
       - run: uv run pytest --cov=agentloom --cov-report=xml --cov-report=term-missing
+      # Coverage upload is informational — the test suite is the quality
+      # gate. The uploader verifies its own downloaded CLI's GPG signature,
+      # and that step has been failing persistently ("gpg: no valid OpenPGP
+      # data found" → "Can't check signature: No public key"), turning every
+      # post-merge push CI red even though all tests passed. ``fail_ci_if_error``
+      # only governs upload errors, not this binary-verification failure, so
+      # ``continue-on-error`` is what actually keeps a Codecov infra failure
+      # from blocking main. The codecov/patch status check still reports on PRs.
       - uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24  # v5
         if: matrix.python-version == '3.12'
+        continue-on-error: true
         with:
           files: coverage.xml
-          fail_ci_if_error: ${{ github.event_name == 'push' }}
+          fail_ci_if_error: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## What

Adds `continue-on-error: true` (and `fail_ci_if_error: false`) to the Codecov upload step in `ci.yml`.

## Why

Every post-merge push CI run (#155, #156, #157) has failed at the Codecov step — not on tests, which pass on Python 3.11/3.12/3.13. The `codecov/codecov-action@v5` wrapper verifies the GPG signature of the codecov CLI binary it downloads, and that verification fails persistently:

```
gpg: no valid OpenPGP data found.
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
    Exiting...
Error: Process completed with exit code 1.
```

The step only runs on Python 3.12 (`if: matrix.python-version == '3.12'`) and was fatal on `push` (`fail_ci_if_error: ${{ github.event_name == 'push' }}`), so a Codecov infrastructure failure turned main red on every merge. A manual re-run reproduced the identical GPG error, confirming it is persistent, not transient. `fail_ci_if_error` only governs upload errors, not the CLI binary-verification failure — so `continue-on-error: true` is what actually keeps the job green. Coverage upload is informational; the test suite is the quality gate, and the `codecov/patch` status check still reports on PRs.

## Testing

- `ci.yml` validated as well-formed YAML.
- Behaviour: the Codecov step now surfaces as a non-blocking warning when its GPG verification fails, instead of failing the job.